### PR TITLE
fix: syntax on validation request data

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -11,7 +11,7 @@ class TaskController extends Controller
 {
     public function store(TaskRequest $request)
     {
-        $validatedData = $request->validate($request->validated());
+        $validatedData = $request->validate($request->rules());
 
         Auth::user()->tasks()->create($validatedData);
 
@@ -32,7 +32,7 @@ class TaskController extends Controller
 
     public function update(TaskRequest $request, Task $task)
     {
-        $validatedData = $request->validate($request->validated());
+        $validatedData = $request->validate($request->rules());
 
         $task->update($validatedData);
 

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -13,7 +13,7 @@ class TransactionController extends Controller
     {
         $user = Auth::user();
 
-        $validatedData = $request->validate($request->validated());
+        $validatedData = $request->validate($request->rules());
 
         $type = $request->type;
         $amount = $request->amount;
@@ -41,7 +41,7 @@ class TransactionController extends Controller
         TransactionRequest $request,
         Transaction $transaction
     ) {
-        $validatedData = $request->validate($request->validated());
+        $validatedData = $request->validate($request->rules());
 
         $amount = $request->amount;
         $type = $request->type;


### PR DESCRIPTION
$request->validated() returns the request validated data; what is needed as the argument of $request->validate are actually the rules to validate the request data.