### PR TITLE
fix: crash on views involving categories if the entity instance has no category associated with

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -27,7 +27,7 @@
                     <select name="task_category_id" id="task_category_id">
                         @foreach ($taskCategories as $taskCategory)
                             <option value="{{ $taskCategory->id }}"
-                                {{ old('task_category_id', $task->taskCategory->task_category_id) === $taskCategory->id ? 'selected' : '' }}>
+                                {{ old('task_category_id', $task->taskCategory?->id) === $taskCategory->id ? 'selected' : '' }}>
                                 {{ ucFirst($taskCategory->name) }}</option>
                         @endforeach
                     </select>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -14,7 +14,7 @@
         <tbody>
             @foreach (auth()->user()->tasks as $task)
                 <tr>
-                    <td>{{ $task->taskCategory->name }}</td>
+                    <td>{{ $task->taskCategory?->name ?? 'none' }}</td>
                     <td><a href="{{ route('tasks.show', $task) }}">{{ $task->title }}</a></td>
                     <td>{{ Str::limit($task->description, 20, '...') }}</td>
                     <td>{{ $task->created_at->format('m-d-Y') }}</td>

--- a/resources/views/tasks/show.blade.php
+++ b/resources/views/tasks/show.blade.php
@@ -13,7 +13,7 @@
         <tr>
             <td>{{ $task->title }}</td>
             <td>{{ $task->description }}</td>
-            <td>{{ $task->taskCategory->name }}</td>
+            <td>{{ $task->taskCategory?->name ?? 'none' }}</td>
             <td>{{ $task->due_date->format('m-d-Y') }}</td>
             <td>{{ $task->status }}</td>
         </tr>

--- a/resources/views/transactions/edit.blade.php
+++ b/resources/views/transactions/edit.blade.php
@@ -35,7 +35,7 @@
                     <select name="transaction_category_id" id="transaction_category_id">
                         @foreach ($transactionCategories as $transactionCategory)
                             <option value="{{ $transactionCategory->id }}"
-                                {{ old('transaction_category_id', $transaction->transactionCategory->id) == $transactionCategory->id ? 'selected' : '' }}>
+                                {{ old('transaction_category_id', $transaction->transactionCategory?->id) == $transactionCategory->id ? 'selected' : '' }}>
                                 {{ $transactionCategory->name }}
                             </option>
                         @endforeach

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -16,7 +16,7 @@
                 <tr>
                     <td>{{ $transaction->amount }}</td>
                     <td>{{ $transaction->type }}</td>
-                    <td>{{ $transaction->transactionCategory->name }}</td>
+                    <td>{{ $transaction->transactionCategory?->name ?? 'none' }}</td>
                     <td>{{ Str::limit($transaction->description, 20, '...') }}</td>
                     <td>{{ $transaction->created_at->format('m-d-Y') }}</td>
                     <td>

--- a/resources/views/transactions/show.blade.php
+++ b/resources/views/transactions/show.blade.php
@@ -12,7 +12,7 @@
         <tr>
             <td>{{ $transaction->amount }}</td>
             <td>{{ $transaction->type }}</td>
-            <td>{{ $transaction->transactionCategory->name }}</td>
+            <td>{{ $transaction->transactionCategory?->name ?? 'none' }}</td>
             <td>{{ $transaction->created_at->format('m-d-Y') }}</td>
         </tr>
     </tbody>


### PR DESCRIPTION
It's possible to create a task or transaction without a category associated with. This possibility is now reflected in task/transaction-related views.