### PR TITLE
Refactor/allow null selection for category fields

### DIFF
--- a/app/Http/Requests/TaskRequest.php
+++ b/app/Http/Requests/TaskRequest.php
@@ -22,7 +22,7 @@ class TaskRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'task_category_id' => 'exists:task_categories,id',
+            'task_category_id' => 'nullable|exists:task_categories,id',
             'title' => 'required|string|max:255',
             'description' => 'nullable|string|max:65535',
             'due_date' => 'required|date',

--- a/app/Http/Requests/TransactionRequest.php
+++ b/app/Http/Requests/TransactionRequest.php
@@ -24,7 +24,8 @@ class TransactionRequest extends FormRequest
         return [
             'user_id' => 'exists:users,id',
             'bill_id' => 'exists:bills,id',
-            'transaction_category_id' => 'exists:transaction_categories,id',
+            'transaction_category_id' =>
+                'nullable|exists:transaction_categories,id',
             'amount' => 'required|numeric',
             'type' => 'string|in:income,expense',
             'description' => 'required|string|max:65535',

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -23,6 +23,8 @@
                 <div class="form-group">
                     <label for="task_category_id">Category</label>
                     <select name="task_category_id" id="category">
+                        <option value="">Select a category</option>
+
                         @foreach ($taskCategories as $taskCategory)
                             <option value="{{ $taskCategory->id }}"
                                 {{ old('task_category_id') === $taskCategory->id ? 'selected' : '' }}>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -25,6 +25,8 @@
                 <div class="form-group">
                     <label for="task_category_id">Category:</label>
                     <select name="task_category_id" id="task_category_id">
+                        <option value="">Select a category</option>
+
                         @foreach ($taskCategories as $taskCategory)
                             <option value="{{ $taskCategory->id }}"
                                 {{ old('task_category_id', $task->taskCategory?->id) === $taskCategory->id ? 'selected' : '' }}>

--- a/resources/views/transactions/create.blade.php
+++ b/resources/views/transactions/create.blade.php
@@ -26,7 +26,9 @@
                 </div>
                 <div class="form-group">
                     <label for="transaction_category_id">Category:</label>
-                    <select name="transaction_category_id" id="transaction_category_id"></select>
+                    <select name="transaction_category_id" id="transaction_category_id">
+                        <option value="">Select a category</option>
+                    </select>
                 </div>
                 <div class="form-group">
                     <label for="description">Description:</label>

--- a/resources/views/transactions/create.blade.php
+++ b/resources/views/transactions/create.blade.php
@@ -57,9 +57,16 @@
                 const categorySelect = document.getElementById('transaction_category_id');
                 const oldCategoryId = "{{ old('transaction_category_id') }}";
 
-                categorySelect.innerHTML = categories.map(function(category) {
-                    return `<option value="${category.id}" ${oldCategoryId == category.id ? 'selected' : ''}>${category.name}</option>`;
-                }).join('');
+                categories.forEach((category) => {
+                    const option = document.createElement('option');
+                    option.value = category.id;
+                    option.textContent = category.name;
+
+                    if (oldCategoryId == category.id) {
+                        option.selected = true;
+                    }
+                    categorySelect.appendChild(option);
+                });
 
                 loadingElement.classList.add('hidden');
                 overlayElement.style.display = 'none';


### PR DESCRIPTION
The entities with category-related fields can have them null, but this was enforced only at database level. Now it's possible to create a task or transaction without a category associated with at the application level - considering the models and the views.