### PR TITLE
fix: correctly get the next pending task/bill due date

### DIFF
--- a/app/Http/Controllers/WalletController.php
+++ b/app/Http/Controllers/WalletController.php
@@ -16,19 +16,31 @@ class WalletController extends Controller
         $balance = $user->balance;
         $full_name = $user->full_name;
         $lastTransaction = $user->transactions->last();
-        $nextBillDueDate = Cache::remember(
+        $nextPendingBillDueDate = Cache::remember(
             "user_{$userId}_next_bill_due",
             60,
             function () use ($user) {
-                $bill = $user->bills()->orderBy('due_date', 'asc')->first();
+                $bill = $user
+                    ->bills()
+                    ->where('due_date', '>=', now())
+                    ->where('status', '=', 'pending')
+                    ->orderBy('due_date', 'asc')
+                    ->first();
+
                 return $bill ? $bill->due_date->format('Y-m-d') : 'none';
             }
         );
-        $nextTaskDueDate = Cache::remember(
+        $nextPendingTaskDueDate = Cache::remember(
             "user_{$userId}_next_task_due",
             60,
             function () use ($user) {
-                $task = $user->tasks()->orderBy('due_date', 'asc')->first();
+                $task = $user
+                    ->tasks()
+                    ->where('due_date', '>=', now())
+                    ->where('status', '=', 'pending')
+                    ->orderBy('due_date', 'asc')
+                    ->first();
+
                 return $task ? $task->due_date->format('Y-m-d') : 'none';
             }
         );
@@ -39,8 +51,8 @@ class WalletController extends Controller
             compact(
                 'balance',
                 'full_name',
-                'nextBillDueDate',
-                'nextTaskDueDate',
+                'nextPendingBillDueDate',
+                'nextPendingTaskDueDate',
                 'lastTransaction'
             )
         );

--- a/resources/views/wallet/show.blade.php
+++ b/resources/views/wallet/show.blade.php
@@ -10,10 +10,10 @@ $user = auth()->user();
 
             <p><span>Balance:</span> ${{ $balance }}</p>
             <p><span>Next Bill Due:</span>
-                {{ $nextBillDueDate }}
+                {{ $nextPendingBillDueDate ?? 'none' }}
             </p>
             <p><span>Next Task Due:</span>
-                {{ $nextTaskDueDate }}
+                {{ $nextPendingTaskDueDate ?? 'none' }}
             </p>
             <p><span>Last Transaction:</span>
                 @if ($lastTransaction)


### PR DESCRIPTION
The queries before were fetching the tasks/bills which due_date was the latest one; now they fetch the data considering these conditions: the due_date has to be in the future, the status has to be 'pending' and from the result set get on these conditions, get the first on ascending order - that is: the nearest future pending bill due_date. The views were changed to comply with this fixing, and now consider that no data as return from the query is a possibility - 'none'.