### PR TITLE
fix: handle due_date as carbon instance instead of date string

### DIFF
--- a/app/CacheHandlers/BillCacheHandler.php
+++ b/app/CacheHandlers/BillCacheHandler.php
@@ -15,11 +15,11 @@ class BillCacheHandler
 
             if (
                 !$nextPendingBillDueDate ||
-                $bill->due_date->format('Y-m-d') < $nextPendingBillDueDate
+                $bill->due_date < $nextPendingBillDueDate
             ) {
                 Cache::put(
                     "user_{$bill->user_id}_next_bill_due",
-                    $bill->due_date->format('Y-m-d'),
+                    $bill->due_date,
                     60
                 );
             }
@@ -31,19 +31,17 @@ class BillCacheHandler
         if ($bill->due_date->isFuture() && $bill->status == 'pending') {
             $nextPendingBillDueDate =
                 Cache::get("user_{$bill->user_id}_next_bill_due") ??
-                ($bill->user
+                $bill->user
                     ->bills()
                     ->where('due_date', '>=', now())
                     ->where('status', '=', 'pending')
                     ->orderBy('due_date', 'asc')
-                    ->first()
-                    ?->due_date->format('Y-m-d') ??
-                    'none');
+                    ->first()?->due_date;
 
-            $bill->due_date->format('Y-m-d') < $nextPendingBillDueDate
+            $bill->due_date < $nextPendingBillDueDate
                 ? Cache::put(
                     "user_{$bill->user_id}_next_bill_due",
-                    $bill->due_date->format('Y-m-d'),
+                    $bill->due_date,
                     60
                 )
                 : Cache::add(
@@ -68,8 +66,7 @@ class BillCacheHandler
                     ->where('due_date', '>=', now())
                     ->where('status', '=', 'pending')
                     ->orderBy('due_date', 'asc')
-                    ->first()
-                    ?->due_date->format('Y-m-d') ?? 'none',
+                    ->first()?->due_date,
                 60
             );
         }

--- a/app/CacheHandlers/TaskCacheHandler.php
+++ b/app/CacheHandlers/TaskCacheHandler.php
@@ -15,11 +15,11 @@ class TaskCacheHandler
 
             if (
                 !$nextPendingTaskDueDate ||
-                $task->due_date->format('Y-m-d') < $nextPendingTaskDueDate
+                $task->due_date < $nextPendingTaskDueDate
             ) {
                 Cache::put(
                     "user_{$task->user_id}_next_task_due",
-                    $task->due_date->format('Y-m-d'),
+                    $task->due_date,
                     60
                 );
             }
@@ -31,19 +31,17 @@ class TaskCacheHandler
         if ($task->due_date->isFuture() && $task->status == 'pending') {
             $nextPendingTaskDueDate =
                 Cache::get("user_{$task->user_id}_next_task_due") ??
-                ($task->user
+                $task->user
                     ->tasks()
                     ->where('due_date', '>=', now())
                     ->where('status', '=', 'pending')
                     ->orderBy('due_date', 'asc')
-                    ->first()
-                    ?->due_date->format('Y-m-d') ??
-                    'none');
+                    ->first()?->due_date;
 
-            $task->due_date->format('Y-m-d') < $nextPendingTaskDueDate
+            $task->due_date < $nextPendingTaskDueDate
                 ? Cache::put(
                     "user_{$task->user_id}_next_task_due",
-                    $task->due_date->format('Y-m-d'),
+                    $task->due_date,
                     60
                 )
                 : Cache::add(
@@ -68,8 +66,7 @@ class TaskCacheHandler
                     ->where('due_date', '>=', now())
                     ->where('status', '=', 'pending')
                     ->orderBy('due_date', 'asc')
-                    ->first()
-                    ?->due_date->format('Y-m-d') ?? 'none',
+                    ->first()?->due_date,
                 60
             );
         }

--- a/app/Http/Controllers/WalletController.php
+++ b/app/Http/Controllers/WalletController.php
@@ -20,28 +20,28 @@ class WalletController extends Controller
             "user_{$userId}_next_bill_due",
             60,
             function () use ($user) {
-                $bill = $user
+                $queriedNextPendingBillDueDate = $user
                     ->bills()
                     ->where('due_date', '>=', now())
                     ->where('status', '=', 'pending')
                     ->orderBy('due_date', 'asc')
-                    ->first();
+                    ->first()?->due_date;
 
-                return $bill ? $bill->due_date->format('Y-m-d') : 'none';
+                return $queriedNextPendingBillDueDate ?? 'none';
             }
         );
         $nextPendingTaskDueDate = Cache::remember(
             "user_{$userId}_next_task_due",
             60,
             function () use ($user) {
-                $task = $user
+                $queriedNextPendingTaskDueDate = $user
                     ->tasks()
                     ->where('due_date', '>=', now())
                     ->where('status', '=', 'pending')
                     ->orderBy('due_date', 'asc')
-                    ->first();
+                    ->first()?->due_date;
 
-                return $task ? $task->due_date->format('Y-m-d') : 'none';
+                return $queriedNextPendingTaskDueDate ?? 'none';
             }
         );
 

--- a/resources/views/wallet/show.blade.php
+++ b/resources/views/wallet/show.blade.php
@@ -10,10 +10,10 @@ $user = auth()->user();
 
             <p><span>Balance:</span> ${{ $balance }}</p>
             <p><span>Next Bill Due:</span>
-                {{ $nextPendingBillDueDate ?? 'none' }}
+                {{ $nextPendingBillDueDate->format('Y-m-d') ?? 'none' }}
             </p>
             <p><span>Next Task Due:</span>
-                {{ $nextPendingTaskDueDate ?? 'none' }}
+                {{ $nextPendingTaskDueDate->format('Y-m-d') ?? 'none' }}
             </p>
             <p><span>Last Transaction:</span>
                 @if ($lastTransaction)


### PR DESCRIPTION
the due_date in tasks and bills is now stored as a carbon instance instead of a date formatted as string: to compare dates correctly they have to be carbon instances.