### PR TITLE
fix: format date on 'none' error in wallet

### DIFF
--- a/app/Http/Controllers/WalletController.php
+++ b/app/Http/Controllers/WalletController.php
@@ -27,7 +27,7 @@ class WalletController extends Controller
                     ->orderBy('due_date', 'asc')
                     ->first()?->due_date;
 
-                return $queriedNextPendingBillDueDate ?? 'none';
+                return $queriedNextPendingBillDueDate;
             }
         );
         $nextPendingTaskDueDate = Cache::remember(
@@ -41,7 +41,7 @@ class WalletController extends Controller
                     ->orderBy('due_date', 'asc')
                     ->first()?->due_date;
 
-                return $queriedNextPendingTaskDueDate ?? 'none';
+                return $queriedNextPendingTaskDueDate;
             }
         );
 


### PR DESCRIPTION
if 'none' is stored in the cache record related to the nextPendingBillDueDate, then in the wallet.show view the '->format()' can be tried to be applied on 'none' if the query in walletController returns null. In order to avoid that error, now the query can return null and not 'none'.