### PR TITLE
fix: fix bill cache handling on updating

### DIFF
--- a/app/Listeners/HandleBillCache.php
+++ b/app/Listeners/HandleBillCache.php
@@ -61,6 +61,7 @@ class HandleBillCache
     private static function handleUpdatedBill(BillUpdated $event)
     {
         $bill = $event->getEntity();
+        $bill->refresh();
 
         if ($bill->due_date->isFuture() && $bill->status == 'pending') {
             $nextPendingBillDueDate =

--- a/app/Listeners/HandleTaskCache.php
+++ b/app/Listeners/HandleTaskCache.php
@@ -60,6 +60,7 @@ class HandleTaskCache
     private static function handleUpdatedTask(TaskUpdated $event)
     {
         $task = $event->getEntity();
+        $task->refresh();
 
         if ($task->due_date->isFuture() && $task->status == 'pending') {
             $nextPendingTaskDueDate =


### PR DESCRIPTION
the bill data was incorrect when the cache related to the bill entity was being handled after a bill update: it was considering the bill data before the update in the database.