### PR TITLE
refactor: improve queries to avoid fetching unnecessary data

### DIFF
--- a/app/Http/Controllers/WalletController.php
+++ b/app/Http/Controllers/WalletController.php
@@ -15,7 +15,7 @@ class WalletController extends Controller
 
         $balance = $user->balance;
         $full_name = $user->full_name;
-        $lastTransaction = $user->transactions->last();
+        $lastTransaction = $user->transactions()->latest('created_at')->first();
         $nextPendingBillDueDate = Cache::remember(
             "user_{$userId}_next_bill_due",
             60,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -56,7 +56,7 @@ class User extends Authenticatable
 
     public function getBalanceAttribute()
     {
-        $balance = $this->transactions->sum('amount');
+        $balance = $this->transactions()->sum('amount');
         return number_format($balance, 2);
     }
 

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -29,7 +29,7 @@
 
                         @foreach ($taskCategories as $taskCategory)
                             <option value="{{ $taskCategory->id }}"
-                                {{ old('task_category_id', $task->taskCategory?->id) === $taskCategory->id ? 'selected' : '' }}>
+                                {{ old('task_category_id', $task->taskCategory()->id) === $taskCategory->id ? 'selected' : '' }}>
                                 {{ ucFirst($taskCategory->name) }}</option>
                         @endforeach
                     </select>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -59,7 +59,7 @@
         <tbody>
             @foreach ($tasks as $task)
                 <tr>
-                    <td>{{ $task->taskCategory?->name ?? 'none' }}</td>
+                    <td>{{ $task->taskCategory()->name ?? 'none' }}</td>
                     <td>{{ $task->status }}</td>
                     <td><a href="{{ route('tasks.show', $task) }}">{{ $task->title }}</a></td>
                     <td>{{ Str::limit($task->description, 20, '...') }}</td>

--- a/resources/views/tasks/show.blade.php
+++ b/resources/views/tasks/show.blade.php
@@ -13,7 +13,7 @@
         <tr>
             <td>{{ $task->title }}</td>
             <td>{{ $task->description }}</td>
-            <td>{{ $task->taskCategory?->name ?? 'none' }}</td>
+            <td>{{ $task->taskCategory()->name ?? 'none' }}</td>
             <td>{{ $task->due_date->format('m-d-Y') }}</td>
             <td>{{ $task->status }}</td>
         </tr>

--- a/resources/views/transactions/edit.blade.php
+++ b/resources/views/transactions/edit.blade.php
@@ -35,7 +35,7 @@
                     <select name="transaction_category_id" id="transaction_category_id">
                         @foreach ($transactionCategories as $transactionCategory)
                             <option value="{{ $transactionCategory->id }}"
-                                {{ old('transaction_category_id', $transaction->transactionCategory?->id) == $transactionCategory->id ? 'selected' : '' }}>
+                                {{ old('transaction_category_id', $transaction->transactionCategory()->id) == $transactionCategory->id ? 'selected' : '' }}>
                                 {{ $transactionCategory->name }}
                             </option>
                         @endforeach

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -69,7 +69,7 @@
                 <tr>
                     <td>{{ $transaction->amount }}</td>
                     <td>{{ $transaction->type }}</td>
-                    <td>{{ $transaction->transactionCategory?->name ?? 'none' }}</td>
+                    <td>{{ $transaction->transactionCategory()->name ?? 'none' }}</td>
                     <td>{{ Str::limit($transaction->description, 20, '...') }}</td>
                     <td>{{ $transaction->created_at->format('m-d-Y') }}</td>
                     <td>

--- a/resources/views/transactions/show.blade.php
+++ b/resources/views/transactions/show.blade.php
@@ -12,7 +12,7 @@
         <tr>
             <td>{{ $transaction->amount }}</td>
             <td>{{ $transaction->type }}</td>
-            <td>{{ $transaction->transactionCategory?->name ?? 'none' }}</td>
+            <td>{{ $transaction->transactionCategory()->name ?? 'none' }}</td>
             <td>{{ $transaction->created_at->format('m-d-Y') }}</td>
         </tr>
     </tbody>

--- a/resources/views/wallet/show.blade.php
+++ b/resources/views/wallet/show.blade.php
@@ -19,7 +19,7 @@ $user = auth()->user();
                 @if ($lastTransaction)
                     Amount: ${{ $lastTransaction->amount }} |
                     Type: {{ $lastTransaction->type }} |
-                    Category: {{ $lastTransaction->transactionCategory->name ?? 'none' }} |
+                    Category: {{ $lastTransaction->transactionCategory()->name ?? 'none' }} |
                     Description: {{ Str::limit($lastTransaction->description, 5, '...') ?? 'none' }}
                 @else
                     None


### PR DESCRIPTION
in some places of the application unnecessary extra queries were being executed: instead of getting a query builder instance from a relationship of a model and continue to build the query before execution, a query was executed fetching the related data and just then another query was executed based on the fetched data.