### PR TITLE
feat: benchmark tests for wallet routes

### DIFF
--- a/tests/Benchmark/WalletRoutesBench.php
+++ b/tests/Benchmark/WalletRoutesBench.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\tests\Benchmark;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+class WalletRoutesBench
+{
+    public function __construct()
+    {
+        $this->bootstrapLaravel();
+    }
+
+    private function bootstrapLaravel()
+    {
+        $app = require __DIR__ . '/../../bootstrap/app.php';
+        $app->make(Kernel::class)->bootstrap();
+    }
+
+    /**
+     * @Revs(1000)
+     * @Iterations(3)
+     */
+    public function benchShow()
+    {
+        DB::beginTransaction(); /* wrapping up even here to avoid cache table to persist data */
+
+        $user = User::first(); /* assuming that the TestUserSeeder has already been run. */
+        Auth::login($user);
+
+        Route::dispatch(Request::create('/wallet', 'GET'));
+
+        DB::rollback();
+    }
+}


### PR DESCRIPTION
benchmark class with tests for the wallet routes (in this case, there's at the moment only one route: show). The structure used for the benchmark tests is the following: a benchmark class with methods that execute a code that sends a request to an endpoint. It's important to add up that it's assured that the database changes after the request are not persisted at the database at the end of the method execution.