### PR TITLE
fix: cache not updating properly on cache handlers update

### DIFF
--- a/app/Listeners/HandleBillCache.php
+++ b/app/Listeners/HandleBillCache.php
@@ -71,7 +71,7 @@ class HandleBillCache
                     ->orderBy('due_date', 'asc')
                     ->first()?->due_date;
 
-            $bill->due_date < $nextPendingBillDueDate
+            $bill->due_date <= $nextPendingBillDueDate
                 ? Cache::put(
                     "user_{$bill->user_id}_next_bill_due",
                     $bill->due_date,

--- a/app/Listeners/HandleTaskCache.php
+++ b/app/Listeners/HandleTaskCache.php
@@ -71,7 +71,7 @@ class HandleTaskCache
                     ->orderBy('due_date', 'asc')
                     ->first()?->due_date;
 
-            $task->due_date < $nextPendingTaskDueDate
+            $task->due_date <= $nextPendingTaskDueDate
                 ? Cache::put(
                     "user_{$task->user_id}_next_task_due",
                     $task->due_date,


### PR DESCRIPTION
The case where the task or bill updated is the same whose due_date has been cached before wasn't handled properly (the cache wasn't updating the cache value stored).