### PR TITLE
fix: crash on transactions and tasks edit views due to incorrect query

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -29,7 +29,7 @@
 
                         @foreach ($taskCategories as $taskCategory)
                             <option value="{{ $taskCategory->id }}"
-                                {{ old('task_category_id', $task->taskCategory()->id) === $taskCategory->id ? 'selected' : '' }}>
+                                {{ old('task_category_id', $task->taskCategory->id) === $taskCategory->id ? 'selected' : '' }}>
                                 {{ ucFirst($taskCategory->name) }}</option>
                         @endforeach
                     </select>

--- a/resources/views/transactions/edit.blade.php
+++ b/resources/views/transactions/edit.blade.php
@@ -35,7 +35,7 @@
                     <select name="transaction_category_id" id="transaction_category_id">
                         @foreach ($transactionCategories as $transactionCategory)
                             <option value="{{ $transactionCategory->id }}"
-                                {{ old('transaction_category_id', $transaction->transactionCategory()->id) == $transactionCategory->id ? 'selected' : '' }}>
+                                {{ old('transaction_category_id', $transaction->transactionCategory->id) == $transactionCategory->id ? 'selected' : '' }}>
                                 {{ $transactionCategory->name }}
                             </option>
                         @endforeach


### PR DESCRIPTION
the '()' after the transaction/taskCategory was making the returned value of the expression as a query builder. The intention was to get the id of the transaction/taskCategory returned by a query to fetch the associated transaction/taskCategory to the transaction/task.