### PR TITLE
fix: filtering tests occasionally failing

### DIFF
--- a/tests/Feature/Bill/BillsFilteringTest.php
+++ b/tests/Feature/Bill/BillsFilteringTest.php
@@ -23,10 +23,7 @@ test('bills.index screen filters bills correctly', function () {
 
     $response = $this->actingAs($user)->get(
         route('bills.index', [
-            'filterByStatus' => $faker->randomElement([
-                'pending',
-                ['pending', 'paid'],
-            ]),
+            'filterByStatus' => $faker->randomElement(['pending', 'paid']),
         ])
     );
 

--- a/tests/Feature/Task/TasksFilteringTest.php
+++ b/tests/Feature/Task/TasksFilteringTest.php
@@ -26,10 +26,7 @@ test('tasks.index screen filters tasks correctly', function () {
 
     $response = $this->actingAs($user)->get(
         route('tasks.index', [
-            'filterByStatus' => $faker->randomElement([
-                'pending',
-                ['pending', 'completed'],
-            ]),
+            'filterByStatus' => $faker->randomElement(['pending', 'completed']),
         ])
     );
 
@@ -53,4 +50,3 @@ test('tasks.index screen filters tasks correctly', function () {
     });
 });
 
-// feature/sorting-tests-on-bills-tasks-transactions - to be done


### PR DESCRIPTION
the filtering tests were failing depending on the status randomly choosed to be filtered by the database (if it had been just pending, the test would fail if the status of at least one of the includedEntities had been completed).