### PR TITLE
Fix/transactions amount-type handling bug

### DIFF
--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -21,10 +21,10 @@ class TransactionController extends Controller
 
         $validatedData = $request->validated();
 
-        $type = $request->type;
-        $amount = $request->amount;
+        $validatedData['amount'] = abs($validatedData['amount']);
 
-        $type === 'expense' && ($amount = -$amount);
+        $validatedData['type'] === 'expense' &&
+            ($validatedData['amount'] = -$validatedData['amount']);
 
         $user->transactions()->create($validatedData);
 
@@ -56,14 +56,10 @@ class TransactionController extends Controller
     ) {
         $validatedData = $request->validated();
 
-        $amount = $request->amount;
-        $type = $request->type;
+        $validatedData['amount'] = abs($validatedData['amount']);
 
-        $amount =
-            ($type === 'expense' && $amount > 0) ||
-            ($type === 'income' && $amount < 0)
-                ? -$amount
-                : $amount;
+        $validatedData['type'] === 'expense' &&
+            ($validatedData['amount'] = -$validatedData['amount']);
 
         $transaction->update($validatedData);
 

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -21,11 +21,6 @@ class TransactionController extends Controller
 
         $validatedData = $request->validated();
 
-        $validatedData['amount'] = abs($validatedData['amount']);
-
-        $validatedData['type'] === 'expense' &&
-            ($validatedData['amount'] = -$validatedData['amount']);
-
         $user->transactions()->create($validatedData);
 
         return redirect()->back();
@@ -55,11 +50,6 @@ class TransactionController extends Controller
         Transaction $transaction
     ) {
         $validatedData = $request->validated();
-
-        $validatedData['amount'] = abs($validatedData['amount']);
-
-        $validatedData['type'] === 'expense' &&
-            ($validatedData['amount'] = -$validatedData['amount']);
 
         $transaction->update($validatedData);
 

--- a/database/migrations/2024_06_24_122022_add_triggers_to_transactions_table.php
+++ b/database/migrations/2024_06_24_122022_add_triggers_to_transactions_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AddTriggersToTransactionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     */
+    public function up()
+    {
+        DB::unprepared('
+            CREATE TRIGGER before_transactions_insert
+            BEFORE INSERT ON transactions
+            FOR EACH ROW
+            BEGIN
+                IF NEW.type = "expense" THEN
+                    SET NEW.amount = -ABS(NEW.amount);
+                ELSEIF NEW.type = "income" THEN
+                    SET NEW.amount = ABS(NEW.amount);
+                END IF;
+            END;
+        ');
+
+        DB::unprepared('
+            CREATE TRIGGER before_transactions_update
+            BEFORE UPDATE ON transactions
+            FOR EACH ROW
+            BEGIN
+                IF NEW.type = "expense" THEN
+                    SET NEW.amount = -ABS(NEW.amount);
+                ELSEIF NEW.type = "income" THEN
+                    SET NEW.amount = ABS(NEW.amount);
+                END IF;
+            END;
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     */
+    public function down()
+    {
+        DB::unprepared('DROP TRIGGER IF EXISTS before_transactions_insert');
+        DB::unprepared('DROP TRIGGER IF EXISTS before_transactions_update');
+    }
+}


### PR DESCRIPTION
Fix Applied: Corrected the logic to ensure transaction amounts are stored correctly according to their type. Previously, ‘expense’ transactions could have a positive amount, and ‘income’ transactions a negative one. This fix enforces absolute (positive) values for amounts sent to the server, with the type dictating the final stored value.

Database Trigger Added: Implemented a database-level trigger to automatically adjust transaction amounts based on their type before insert/update operations. This ensures consistency and reliability in how transaction amounts are processed and stored.

Code Simplification: Removed the amount processing logic from the TransactionController, simplifying the code and delegating the responsibility to the database trigger for better separation of concerns.