### PR TITLE
Fix/some transaction tests failing occasionally due to new triggers on transactions

### DIFF
--- a/tests/Feature/Transaction/TransactionFilteringTest.php
+++ b/tests/Feature/Transaction/TransactionFilteringTest.php
@@ -27,19 +27,22 @@ class TransactionFilteringTest extends TestCase
 
     public function testTransactionsIndexScreenFiltersTransactionsCorrectly()
     {
-        $transactionCategory = TransactionCategory::factory()->create();
         $includedTransactions = Transaction::factory()
             ->count(5)
             ->create([
                 'user_id' => $this->user->id,
-                'transaction_category_id' => $transactionCategory->id,
+                'transaction_category_id' => TransactionCategory::factory()->create(
+                    ['transaction_type' => 'income']
+                )->id,
                 'type' => 'income',
             ]);
         $excludedTransactions = Transaction::factory()
             ->count(5)
             ->create([
                 'user_id' => $this->user->id,
-                'transaction_category_id' => $transactionCategory->id,
+                'transaction_category_id' => TransactionCategory::factory()->create(
+                    ['transaction_type' => 'expense']
+                )->id,
                 'type' => 'expense',
             ]);
 

--- a/tests/Feature/Transaction/TransactionStoreTest.php
+++ b/tests/Feature/Transaction/TransactionStoreTest.php
@@ -43,6 +43,11 @@ class TransactionStoreTest extends TestCase
             'description' => $this->faker->paragraph,
             'type' => $type,
         ];
+        $expectedData = Arr::except($transactionData, ['amount']);
+        $expectedData['amount'] =
+            $transactionData['type'] === 'income'
+                ? abs($transactionData['amount'])
+                : -1 * abs($transactionData['amount']);
 
         $response = $this->actingAs($this->user)->post(
             route('transactions.store'),
@@ -50,6 +55,6 @@ class TransactionStoreTest extends TestCase
         );
 
         $response->assertStatus(302);
-        $this->assertDatabaseHas('transactions', $transactionData);
+        $this->assertDatabaseHas('transactions', $expectedData);
     }
 }

--- a/tests/Feature/Transaction/TransactionStoreTest.php
+++ b/tests/Feature/Transaction/TransactionStoreTest.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use App\Models\TransactionCategory;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
 
 class TransactionStoreTest extends TestCase
 {
@@ -30,14 +31,17 @@ class TransactionStoreTest extends TestCase
     public function testTransactionSuccessfullyStored()
     {
         $bill = Bill::factory()->create(['user_id' => $this->user->id]);
-        $transactionCategory = TransactionCategory::factory()->create();
+        $type = $this->faker->randomElement(['income', 'expense']);
+        $transactionCategory = TransactionCategory::factory()->create([
+            'transaction_type' => $type,
+        ]);
         $transactionData = [
             'user_id' => $this->user->id,
             'bill_id' => $bill->id,
             'transaction_category_id' => $transactionCategory->id,
             'amount' => $this->faker->randomFloat(2, 0, 1000),
             'description' => $this->faker->paragraph,
-            'type' => 'expense',
+            'type' => $type,
         ];
 
         $response = $this->actingAs($this->user)->post(

--- a/tests/Feature/Transaction/TransactionUpdateTest.php
+++ b/tests/Feature/Transaction/TransactionUpdateTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use Faker\Factory;
+use Tests\TestCase;
+use App\Models\Bill;
+use App\Models\User;
+use App\Models\Transaction;
+use Illuminate\Support\Arr;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class TransactionUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $faker;
+    protected $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->faker = Factory::create();
+        $this->user = User::factory()->create();
+        Auth::login($this->user);
+    }
+
+    public function testTransactionSuccessfullyUpdated()
+    {
+        $transaction = Transaction::factory()->create([
+            'user_id' => $this->user->id,
+        ]);
+        $transactionUpdateData = [
+            'amount' => $this->faker->randomFloat(2, 0, 1000),
+            'description' => $this->faker->paragraph,
+            'type' => $transaction->type,
+        ];
+        $response = $this->actingAs($this->user)->put(
+            route('transactions.update', $transaction),
+            $transactionUpdateData
+        );
+        $expectedData = Arr::except($transactionUpdateData, ['amount']);
+        $expectedData['amount'] =
+            $transactionUpdateData['type'] === 'income'
+                ? abs($transactionUpdateData['amount'])
+                : -1 * abs($transactionUpdateData['amount']);
+
+        $response->assertStatus(302);
+        $this->assertDatabaseHas('transactions', $expectedData);
+    }
+}


### PR DESCRIPTION
Transaction Category Consistency: Ensures that transactions in TransactionFilteringTest have a transaction_category_id matching the transaction type, addressing previous inconsistencies.

Amount Handling Update: Modifies TransactionStoreTest to account for a new trigger that adjusts stored transaction amounts to be positive or negative based on the transaction type.

New Transaction Update Test: Adds a TransactionUpdateTest to verify the recent changes in transaction amount-type handling logic.