### PR TITLE
refactor: improve charts logic using more library related code

### DIFF
--- a/app/Charts/DailyPaidBillsChart.php
+++ b/app/Charts/DailyPaidBillsChart.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Auth;
 
 class DailyPaidBillsChart extends Chart
 {
-    public $datasetLabel;
+    public $label;
     public $labels;
     public $data;
     public $user;
@@ -34,10 +34,11 @@ class DailyPaidBillsChart extends Chart
             ->orderBy('paid_at')
             ->get();
 
-        $this->datasetLabel = 'Bills paid';
-        $this->labels = $bills->pluck('paid_at');
-        $this->data = $bills->pluck('count_paid');
-        // $this->labels($bills->pluck('paid_at'));
-        // $this->dataset('Daily paid bills', 'line', $bills->pluck('count_paid'));
+        $this->labels($bills->pluck('paid_at'));
+        $this->dataset('Daily paid bills', 'line', $bills->pluck('count_paid'));
+        $this->options([
+            'backgroundColor' => '#FAC189',
+            'borderColor' => '#FAC189',
+        ]);
     }
 }

--- a/app/Charts/DailyTransactionsChart.php
+++ b/app/Charts/DailyTransactionsChart.php
@@ -7,7 +7,7 @@ use ConsoleTVs\Charts\Classes\Chartjs\Chart;
 
 class DailyTransactionsChart extends Chart
 {
-    public $datasetLabel;
+    public $label;
     public $labels;
     public $data;
     public $user;
@@ -36,14 +36,15 @@ class DailyTransactionsChart extends Chart
             ->orderBy('year')
             ->get();
 
-        // $this->labels($transactions->pluck('year'));
-        // $this->dataset(
-        //     'Daily paid bills',
-        //     'line',
-        //     $transactions->pluck('total_amount_paid')
-        // );
-        $this->datasetLabel = 'Total paid on transactions';
-        $this->labels = $transactions->pluck('year');
-        $this->data = $transactions->pluck('total_amount_paid');
+        $this->labels($transactions->pluck('year'));
+        $this->dataset(
+            'Daily paid bills',
+            'line',
+            $transactions->pluck('total_amount_paid')
+        );
+        $this->options([
+            'backgroundColor' => '#FAC189',
+            'borderColor' => '#FAC189',
+        ]);
     }
 }

--- a/app/Charts/MonthlyPaidBillsChart.php
+++ b/app/Charts/MonthlyPaidBillsChart.php
@@ -8,7 +8,7 @@ use ConsoleTVs\Charts\Classes\Chartjs\Chart;
 
 class MonthlyPaidBillsChart extends Chart
 {
-    public $datasetLabel;
+    public $label;
     public $labels;
     public $data;
     public $user;
@@ -37,14 +37,15 @@ class MonthlyPaidBillsChart extends Chart
             ->orderBy('month')
             ->get();
 
-        $this->datasetLabel = 'Bills paid';
-        $this->labels = $bills->pluck('month');
-        $this->data = $bills->pluck('count_paid');
-        // $this->labels($bills->pluck('month'));
-        // $this->dataset(
-        //     'Monthly paid bills',
-        //     'line',
-        //     $bills->pluck('count_paid')
-        // );
+        $this->labels($bills->pluck('month'));
+        $this->dataset(
+            'Monthly paid bills',
+            'line',
+            $bills->pluck('count_paid')
+        );
+        $this->options([
+            'backgroundColor' => '#FAC189',
+            'borderColor' => '#FAC189',
+        ]);
     }
 }

--- a/app/Charts/MonthlyTransactionsChart.php
+++ b/app/Charts/MonthlyTransactionsChart.php
@@ -8,7 +8,7 @@ use Auth;
 
 class MonthlyTransactionsChart extends Chart
 {
-    public $datasetLabel;
+    public $label;
     public $labels;
     public $data;
     public $user;
@@ -37,14 +37,15 @@ class MonthlyTransactionsChart extends Chart
             ->orderBy('year')
             ->get();
 
-        $this->datasetLabel = 'Total paid on transactions';
-        $this->labels = $transactions->pluck('year');
-        $this->data = $transactions->pluck('total_amount_paid');
-        // $this->labels($transactions->pluck('year'));
-        // $this->dataset(
-        //     'Monthly transactions',
-        //     'line',
-        //     $transactions->pluck('total_amount_paid')
-        // );
+        $this->labels($transactions->pluck('year'));
+        $this->dataset(
+            'Monthly transactions',
+            'line',
+            $transactions->pluck('total_amount_paid')
+        );
+        $this->options([
+            'backgroundColor' => '#FAC189',
+            'borderColor' => '#FAC189',
+        ]);
     }
 }

--- a/app/Charts/YearlyPaidBillsChart.php
+++ b/app/Charts/YearlyPaidBillsChart.php
@@ -8,7 +8,7 @@ use ConsoleTVs\Charts\Classes\Chartjs\Chart;
 
 class YearlyPaidBillsChart extends Chart
 {
-    public $datasetLabel;
+    public $label;
     public $labels;
     public $data;
     public $user;
@@ -35,14 +35,11 @@ class YearlyPaidBillsChart extends Chart
             ->orderBy('year')
             ->get();
 
-        $this->datasetLabel = 'Bills paid';
-        $this->labels = $bills->pluck('year');
-        $this->data = $bills->pluck('count_paid');
-        // $this->labels($bills->pluck('year'));
-        // $this->dataset(
-        //     'Yearly paid bills',
-        //     'line',
-        //     $bills->pluck('count_paid')
-        // );
+        $this->labels($bills->pluck('year'));
+        $this->dataset('Bills paid', 'line', $bills->pluck('count_paid'));
+        $this->options([
+            'backgroundColor' => '#FAC189',
+            'borderColor' => '#FAC189',
+        ]);
     }
 }

--- a/app/Charts/YearlyTransactionsChart.php
+++ b/app/Charts/YearlyTransactionsChart.php
@@ -8,7 +8,7 @@ use ConsoleTVs\Charts\Classes\Chartjs\Chart;
 
 class YearlyTransactionsChart extends Chart
 {
-    public $datasetLabel;
+    public $label;
     public $labels;
     public $data;
     public $user;
@@ -37,14 +37,15 @@ class YearlyTransactionsChart extends Chart
             ->orderBy('year')
             ->get();
 
-        $this->datasetLabel = 'Total paid on transactions';
-        $this->labels = $transactions->pluck('year');
-        $this->data = $transactions->pluck('total_amount_paid');
-        // $this->labels($transactions->pluck('year'));
-        // $this->dataset(
-        //     'Yearly transactions',
-        //     'line',
-        //     $transactions->pluck('total_amount_paid')
-        // );
+        $this->labels($transactions->pluck('year'));
+        $this->dataset(
+            'Total paid on transactions',
+            'line',
+            $transactions->pluck('total_amount_paid')
+        );
+        $this->options([
+            'backgroundColor' => '#FAC189',
+            'borderColor' => '#FAC189',
+        ]);
     }
 }

--- a/app/Http/Controllers/BillChartController.php
+++ b/app/Http/Controllers/BillChartController.php
@@ -16,8 +16,8 @@ class BillChartController extends Controller
 
         return response()->json([
             'labels' => $chart->labels,
-            'datasetLabel' => $chart->datasetLabel,
-            'data' => $chart->data,
+            'label' => $chart->datasets[0]->name,
+            'data' => $chart->datasets[0]->values,
         ]);
     }
 

--- a/app/Http/Controllers/TransactionChartController.php
+++ b/app/Http/Controllers/TransactionChartController.php
@@ -12,12 +12,15 @@ class TransactionChartController extends Controller
 {
     public function getTransactions(Request $request)
     {
-        $chart = $this->getChartByRange($request['type'], $request['length']);
+        $chart = $this->getChartByRange(
+            $request->input('type', 'yearly'),
+            $request->input('length', '1')
+        );
 
         return response()->json([
             'labels' => $chart->labels,
-            'datasetLabel' => $chart->datasetLabel,
-            'data' => $chart->data,
+            'label' => $chart->datasets[0]->name,
+            'data' => $chart->datasets[0]->values,
         ]);
     }
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -38,24 +38,13 @@
     </div>
 
     <div style="width: 75%; margin: auto;">
-        <canvas id="dataChart"></canvas>
+        {!! $chart->container() !!}
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    {!! $chart->script() !!}
 
     <script>
-        const ctx = document.getElementById('dataChart').getContext('2d');
-        let dataChart = new Chart(ctx, {
-            type: 'line',
-            data: {
-                labels: @json($labels),
-                datasets: [{
-                    label: @json($datasetLabel),
-                    data: @json($data),
-                }]
-            }
-        });
-
         function updateChart() {
             const dataType = document.getElementById('data-type').value;
             const interval = {
@@ -73,10 +62,10 @@
                 })
                 .then(response => response.json())
                 .then(data => {
-                    dataChart.data.labels = data.labels;
-                    dataChart.data.datasets[0].data = data.data;
-                    dataChart.data.datasets[0].label = data.datasetLabel;
-                    dataChart.update();
+                    window.{{ $chart->id }}.data.labels = data.labels;
+                    window.{{ $chart->id }}.data.datasets[0].data = data.data;
+                    window.{{ $chart->id }}.data.datasets[0].label = data.label;
+                    window.{{ $chart->id }}.update();
                 });
         }
 

--- a/routes/custom/dashboard.php
+++ b/routes/custom/dashboard.php
@@ -10,11 +10,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         $chart = new YearlyTransactionsChart('1');
         $chart->buildChart();
 
-        return view('dashboard', [
-            'labels' => $chart->labels,
-            'datasetLabel' => $chart->datasetLabel,
-            'data' => $chart->data,
-        ]);
+        return view('dashboard', compact('chart'));
     })->name('dashboard');
 
     Route::post('/api/charts/transactions', [


### PR DESCRIPTION
laravel charts provide ways to make the code cleaner on dealing with charts, one of them is that the chart can be shown in the view and mentioned via javascript with an exclusive syntax, avoiding the need to provide too much js code for showing and updating it. ps: one of the resources available there was related to ajax calls, but i haven't implemented it 'cause it does not convey a way to dynamically import the labels calculated in the chart, but only its data.