### PR TITLE
Feature/enforce bills and transactions triggers logic in application level

### DIFF
--- a/app/Http/Controllers/BillController.php
+++ b/app/Http/Controllers/BillController.php
@@ -16,6 +16,10 @@ class BillController extends Controller
 {
     public function store(BillStoreRequest $request)
     {
+        if ($request['status'] === 'paid') {
+            $request->validated()->paid_at = now();
+        }
+
         $bill = Auth::user()->bills()->create($request->validated());
 
         return redirect()->back();
@@ -40,6 +44,10 @@ class BillController extends Controller
 
     public function update(BillUpdateRequest $request, Bill $bill)
     {
+        if ($request['status'] === 'paid' && $bill->status !== 'paid') {
+            $bill->paid_at = now();
+        }
+
         $bill->update($request->validated());
 
         return redirect()->back();

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -19,9 +19,21 @@ class TransactionController extends Controller
     {
         $user = Auth::user();
 
-        $validatedData = $request->validated();
+        $isTransactionValid = TransactionCategory::query()
+            ->where('id', '=', $request['transaction_category_id'])
+            ->where('transaction_type', '=', $request['type'])
+            ->exists();
 
-        $user->transactions()->create($validatedData);
+        if (!$isTransactionValid) {
+            return redirect()
+                ->back()
+                ->withErrors([
+                    'transaction_category' =>
+                    'Invalid transaction category or type.',
+                ]);
+        }
+
+        $validatedData = $request->validated();
 
         return redirect()->back();
     }
@@ -49,6 +61,20 @@ class TransactionController extends Controller
         TransactionUpdateRequest $request,
         Transaction $transaction
     ) {
+        $isTransactionValid = TransactionCategory::query()
+            ->where('id', '=', $request['transaction_category_id'])
+            ->where('transaction_type', '=', $request['type'])
+            ->exists();
+
+        if (!$isTransactionValid) {
+            return redirect()
+                ->back()
+                ->withErrors([
+                    'transaction_category' =>
+                    'Invalid transaction category or type.',
+                ]);
+        }
+
         $validatedData = $request->validated();
 
         $transaction->update($validatedData);

--- a/database/factories/BillFactory.php
+++ b/database/factories/BillFactory.php
@@ -16,20 +16,21 @@ class BillFactory extends Factory
      */
     public function definition(): array
     {
+        $status = $this->faker->randomElement([
+            'pending',
+            'paid',
+            'overdue',
+        ]);
+        $due_date = $this->faker->date();
+        $paidAt = $status !== 'paid' ? null : $this->faker->date(max: $due_date);
+
         return [
             'title' => $this->faker->word,
             'description' => $this->faker->sentence,
             'amount' => $this->faker->randomFloat(2, 0, 10000),
-            'due_date' => $this->faker->date(),
-            'status' => $this->faker->randomElement([
-                'pending',
-                'paid',
-                'overdue',
-            ]),
-            'paid_at' => $this->faker->randomElement([
-                null,
-                $this->faker->date(),
-            ]),
+            'due_date' => $due_date,
+            'status' => $status,
+            'paid_at' => $paidAt,
         ];
     }
 }

--- a/database/migrations/2024_06_30_153657_add_triggers_to_bills_table.php
+++ b/database/migrations/2024_06_30_153657_add_triggers_to_bills_table.php
@@ -28,9 +28,11 @@ class AddTriggersToBillsTable extends Migration
             BEFORE UPDATE ON bills
             FOR EACH ROW
             BEGIN
-                IF NEW.status = "paid" AND OLD.status <> "paid" THEN
+                IF NEW.status = "paid" AND OLD.status <> "paid"
                     SET NEW.paid_at = NOW();
-                ELSEIF NEW.status <> "paid" THEN
+                END IF;
+
+                IF NEW.status != "paid" AND NEW.paid_at <> OLD.paid_at THEN
                     SIGNAL SQLSTATE "45000" SET MESSAGE_TEXT = "Cannot directly update paid_at unless status changes to paid";
                 END IF;
             END;

--- a/database/migrations/2024_06_30_153657_add_triggers_to_bills_table.php
+++ b/database/migrations/2024_06_30_153657_add_triggers_to_bills_table.php
@@ -31,6 +31,8 @@ class AddTriggersToBillsTable extends Migration
                 IF NEW.status = "paid" AND OLD.status <> "paid"
                     SET NEW.paid_at = NOW();
                 END IF;
+            END;
+        ');
 
                 IF NEW.status != "paid" AND NEW.paid_at <> OLD.paid_at THEN
                     SIGNAL SQLSTATE "45000" SET MESSAGE_TEXT = "Cannot directly update paid_at unless status changes to paid";


### PR DESCRIPTION
The previous triggers logic related to bills and transactions has been enforced at the application level to make it easier to handle errors (better than manipulating database errors directly). Also new triggers have been added to enforce the data integrity and business logic:

- the paid_at field of a bill cannot be updated unless the status has changed to or is already paid and if the date informed is in the future.

Also one of the triggers had the logic throwing errors unwantedly and the bill factory has been updated to avoid the creation of invalid bills according to Bill related database triggers.

