### PR TITLE
Feature/authorization owner policies

### DIFF
--- a/app/Http/Controllers/BillController.php
+++ b/app/Http/Controllers/BillController.php
@@ -2,15 +2,16 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\Bill\BillStoreRequest;
-use App\Http\Requests\Bill\BillUpdateRequest;
 use Auth;
 use App\Models\Bill;
 use Illuminate\Http\Request;
 use App\QueryOptions\Sort\Amount;
 use App\QueryOptions\Sort\DueDate;
 use App\QueryOptions\Filter\Status;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Pipeline;
+use App\Http\Requests\Bill\BillStoreRequest;
+use App\Http\Requests\Bill\BillUpdateRequest;
 
 class BillController extends Controller
 {
@@ -39,11 +40,15 @@ class BillController extends Controller
 
     public function show(Bill $bill)
     {
+        Gate::authorize('view', $bill);
+
         return view('bills.show', compact('bill'));
     }
 
     public function update(BillUpdateRequest $request, Bill $bill)
     {
+        Gate::authorize('update', $bill);
+
         if ($request['status'] === 'paid' && $bill->status !== 'paid') {
             $bill->paid_at = now();
         }
@@ -55,6 +60,8 @@ class BillController extends Controller
 
     public function destroy(Bill $bill)
     {
+        Gate::authorize('delete', $bill);
+
         $bill->delete();
 
         return redirect()->back();

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -2,14 +2,15 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\Task\TaskStoreRequest;
-use App\Http\Requests\Task\TaskUpdateRequest;
 use Auth;
 use App\Models\Task;
 use App\Models\TaskCategory;
 use App\QueryOptions\Sort\DueDate;
 use App\QueryOptions\Filter\Status;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Pipeline;
+use App\Http\Requests\Task\TaskStoreRequest;
+use App\Http\Requests\Task\TaskUpdateRequest;
 
 class TaskController extends Controller
 {
@@ -34,11 +35,15 @@ class TaskController extends Controller
 
     public function show(Task $task)
     {
+        Gate::authorize('view', $task);
+
         return view('tasks.show', compact('task'));
     }
 
     public function update(TaskUpdateRequest $request, Task $task)
     {
+        Gate::authorize('update', $task);
+
         $validatedData = $request->validated();
 
         $task->update($validatedData);
@@ -48,6 +53,8 @@ class TaskController extends Controller
 
     public function destroy(Task $task)
     {
+        Gate::authorize('delete', $task);
+
         $task->delete();
 
         return redirect()->back();

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\Transaction\TransactionStoreRequest;
-use App\Http\Requests\Transaction\TransactionUpdateRequest;
 use Request;
 use App\Models\Transaction;
 use App\QueryOptions\Sort\Date;
@@ -11,7 +9,10 @@ use App\QueryOptions\Filter\Type;
 use App\QueryOptions\Sort\Amount;
 use App\Models\TransactionCategory;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Pipeline;
+use App\Http\Requests\Transaction\TransactionStoreRequest;
+use App\Http\Requests\Transaction\TransactionUpdateRequest;
 
 class TransactionController extends Controller
 {
@@ -29,7 +30,7 @@ class TransactionController extends Controller
                 ->back()
                 ->withErrors([
                     'transaction_category' =>
-                    'Invalid transaction category or type.',
+                        'Invalid transaction category or type.',
                 ]);
         }
 
@@ -52,6 +53,8 @@ class TransactionController extends Controller
 
     public function show(Transaction $transaction)
     {
+        Gate::authorize('view', $transaction);
+
         return view('transactions.show', [
             'transaction' => $transaction,
         ]);
@@ -61,6 +64,8 @@ class TransactionController extends Controller
         TransactionUpdateRequest $request,
         Transaction $transaction
     ) {
+        Gate::authorize('update', $transaction);
+
         $isTransactionValid = TransactionCategory::query()
             ->where('id', '=', $request['transaction_category_id'])
             ->where('transaction_type', '=', $request['type'])
@@ -71,7 +76,7 @@ class TransactionController extends Controller
                 ->back()
                 ->withErrors([
                     'transaction_category' =>
-                    'Invalid transaction category or type.',
+                        'Invalid transaction category or type.',
                 ]);
         }
 
@@ -84,6 +89,8 @@ class TransactionController extends Controller
 
     public function destroy(Transaction $transaction)
     {
+        Gate::authorize('delete', $transaction);
+
         $transaction->delete();
 
         return redirect()->back();

--- a/app/Policies/BillPolicy.php
+++ b/app/Policies/BillPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Bill;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class BillPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Bill $bill): bool
+    {
+        return $user->id === $bill->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Bill $bill): bool
+    {
+        return $user->id === $bill->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Bill $bill): bool
+    {
+        return $user->id === $bill->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Bill $bill): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Bill $bill): bool
+    {
+        //
+    }
+}

--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class TaskPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Task $task): bool
+    {
+        return $user->id === $task->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Task $task): bool
+    {
+        return $user->id === $task->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Task $task): bool
+    {
+        return $user->id === $task->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Task $task): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Task $task): bool
+    {
+        //
+    }
+}

--- a/app/Policies/TransactionPolicy.php
+++ b/app/Policies/TransactionPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class TransactionPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Transaction $transaction): bool
+    {
+        return $user->id === $transaction->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Transaction $transaction): bool
+    {
+        return $user->id === $transaction->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Transaction $transaction): bool
+    {
+        return $user->id === $transaction->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Transaction $transaction): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Transaction $transaction): bool
+    {
+        //
+    }
+}


### PR DESCRIPTION
Authorization around ownership implemented to assure security for damages possible on user behavior (such as trying to delete a bill they do not own).

For that, policy classes have been defined with proper methods, which have been added to controllers. In the case of a fail in authorization, the user is prevented from performing the intended actions and a view of unauthorization error is shown.

![Screenshot_525](https://github.com/user-attachments/assets/6e6a784b-c1be-476e-be79-7b9a75c6e326)
