### PR TITLE
feat: add trigger after update transaction category type

### DIFF
--- a/database/migrations/2024_06_30_153657_add_triggers_to_bills_table.php
+++ b/database/migrations/2024_06_30_153657_add_triggers_to_bills_table.php
@@ -28,7 +28,7 @@ class AddTriggersToBillsTable extends Migration
             BEFORE UPDATE ON bills
             FOR EACH ROW
             BEGIN
-                IF NEW.status = "paid" AND OLD.status <> "paid"
+                IF NEW.status = "paid" AND OLD.status <> "paid" THEN
                     SET NEW.paid_at = NOW();
                 END IF;
             END;

--- a/database/migrations/2024_07_28_144835_add_triggers_to_transaction_categories_table.php
+++ b/database/migrations/2024_07_28_144835_add_triggers_to_transaction_categories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::unprepared('
+            CREATE TRIGGER after_transaction_categories_update_in_type
+            AFTER UPDATE ON transaction_categories
+            FOR EACH ROW
+            BEGIN
+                IF NEW.transaction_type != OLD.transaction_type THEN
+                    UPDATE transactions
+                    SET transaction_category_id = NULL
+                    WHERE transaction_category_id = NEW.id;
+                END IF;
+            END;
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared(
+            'DROP TRIGGER IF EXISTS after_transaction_categories_update_in_type'
+        );
+    }
+};


### PR DESCRIPTION
I assured that a transaction only can be related to a transaction_category of the same type, but i haven't considered before the situation where a transaction_category type changes - which is not intended, but can happen. If that happens, now there's a trigger setting the transaction_category as NULL in all transactions related to that transaction_category in transactions table.

![Screenshot_531](https://github.com/user-attachments/assets/6c91167e-0ab1-4a3c-b0f7-8ab24bf973f9)