### PR TITLE
Refactor/move business authorization validation logic away from controllers to request and observer classes

### DIFF
--- a/app/Http/Controllers/BillController.php
+++ b/app/Http/Controllers/BillController.php
@@ -15,6 +15,9 @@ use Illuminate\Support\Facades\Pipeline;
 use App\Http\Requests\Bill\BillStoreRequest;
 use App\Http\Requests\Bill\BillUpdateRequest;
 
+/**
+ * @see \App\Observers\BillObserver
+ */
 class BillController extends Controller
 {
     public function store(BillStoreRequest $request)

--- a/app/Http/Controllers/BillController.php
+++ b/app/Http/Controllers/BillController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\Bill\BillDeleteRequest;
+use App\Http\Requests\Bill\BillShowRequest;
 use Auth;
 use App\Models\Bill;
 use Illuminate\Http\Request;
@@ -38,30 +40,24 @@ class BillController extends Controller
         return view('bills.index', compact('bills'));
     }
 
-    public function show(Bill $bill)
+    public function show(BillShowRequest $bill)
     {
-        Gate::authorize('view', $bill);
-
         return view('bills.show', compact('bill'));
     }
 
     public function update(BillUpdateRequest $request, Bill $bill)
     {
-        Gate::authorize('update', $bill);
+        $bill->update($request->validated());
 
         if ($request['status'] === 'paid' && $bill->status !== 'paid') {
             $bill->paid_at = now();
         }
 
-        $bill->update($request->validated());
-
         return redirect()->back();
     }
 
-    public function destroy(Bill $bill)
+    public function destroy(BillDeleteRequest $bill)
     {
-        Gate::authorize('delete', $bill);
-
         $bill->delete();
 
         return redirect()->back();

--- a/app/Http/Controllers/BillController.php
+++ b/app/Http/Controllers/BillController.php
@@ -19,10 +19,6 @@ class BillController extends Controller
 {
     public function store(BillStoreRequest $request)
     {
-        if ($request['status'] === 'paid') {
-            $request->validated()->paid_at = now();
-        }
-
         $bill = Auth::user()->bills()->create($request->validated());
 
         return redirect()->back();
@@ -48,10 +44,6 @@ class BillController extends Controller
     public function update(BillUpdateRequest $request, Bill $bill)
     {
         $bill->update($request->validated());
-
-        if ($request['status'] === 'paid' && $bill->status !== 'paid') {
-            $bill->paid_at = now();
-        }
 
         return redirect()->back();
     }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -14,6 +14,9 @@ use Illuminate\Support\Facades\Pipeline;
 use App\Http\Requests\Task\TaskStoreRequest;
 use App\Http\Requests\Task\TaskUpdateRequest;
 
+/**
+ * @see \App\Observers\TaskObserver
+ */
 class TaskController extends Controller
 {
     public function store(TaskStoreRequest $request)

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\Task\TaskDeleteRequest;
+use App\Http\Requests\Task\TaskShowRequest;
 use Auth;
 use App\Models\Task;
 use App\Models\TaskCategory;
@@ -33,17 +35,13 @@ class TaskController extends Controller
         return view('tasks.index', compact('tasks'));
     }
 
-    public function show(Task $task)
+    public function show(TaskShowRequest $task)
     {
-        Gate::authorize('view', $task);
-
         return view('tasks.show', compact('task'));
     }
 
     public function update(TaskUpdateRequest $request, Task $task)
     {
-        Gate::authorize('update', $task);
-
         $validatedData = $request->validated();
 
         $task->update($validatedData);
@@ -51,10 +49,8 @@ class TaskController extends Controller
         return redirect()->back();
     }
 
-    public function destroy(Task $task)
+    public function destroy(TaskDeleteRequest $task)
     {
-        Gate::authorize('delete', $task);
-
         $task->delete();
 
         return redirect()->back();

--- a/app/Http/Requests/Bill/BillDeleteRequest.php
+++ b/app/Http/Requests/Bill/BillDeleteRequest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace App\Http\Requests\Task;
+namespace App\Http\Requests\Bill;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 
-class TaskUpdateRequest extends FormRequest
+class BillDeleteRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
-        return Auth::user()->can('update', $this->route('task'));
+        return Auth::user()->can('delete', $this->route('bill'));
     }
 
     /**
@@ -23,10 +23,7 @@ class TaskUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'task_category_id' => 'nullable|exists:task_categories,id',
-            'title' => 'string|max:255',
-            'description' => 'nullable|string|max:65535',
-            'due_date' => 'date',
-        ];
+                //
+            ];
     }
 }

--- a/app/Http/Requests/Bill/BillShowRequest.php
+++ b/app/Http/Requests/Bill/BillShowRequest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace App\Http\Requests\Task;
+namespace App\Http\Requests\Bill;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 
-class TaskUpdateRequest extends FormRequest
+class BillShowRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
-        return Auth::user()->can('update', $this->route('task'));
+        return Auth::user()->can('view', $this->route('bill'));
     }
 
     /**
@@ -23,10 +23,7 @@ class TaskUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'task_category_id' => 'nullable|exists:task_categories,id',
-            'title' => 'string|max:255',
-            'description' => 'nullable|string|max:65535',
-            'due_date' => 'date',
-        ];
+                //
+            ];
     }
 }

--- a/app/Http/Requests/Bill/BillUpdateRequest.php
+++ b/app/Http/Requests/Bill/BillUpdateRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Bill;
 
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Foundation\Http\FormRequest;
 
 class BillUpdateRequest extends FormRequest
@@ -11,7 +12,7 @@ class BillUpdateRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return Auth::user()->can('update', $this->route('bill'));
     }
 
     /**

--- a/app/Http/Requests/Task/TaskDeleteRequest.php
+++ b/app/Http/Requests/Task/TaskDeleteRequest.php
@@ -5,14 +5,14 @@ namespace App\Http\Requests\Task;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 
-class TaskUpdateRequest extends FormRequest
+class TaskDeleteRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
-        return Auth::user()->can('update', $this->route('task'));
+        return Auth::user()->can('delete', $this->route('task'));
     }
 
     /**
@@ -23,10 +23,7 @@ class TaskUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'task_category_id' => 'nullable|exists:task_categories,id',
-            'title' => 'string|max:255',
-            'description' => 'nullable|string|max:65535',
-            'due_date' => 'date',
-        ];
+                //
+            ];
     }
 }

--- a/app/Http/Requests/Task/TaskShowRequest.php
+++ b/app/Http/Requests/Task/TaskShowRequest.php
@@ -5,14 +5,14 @@ namespace App\Http\Requests\Task;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 
-class TaskUpdateRequest extends FormRequest
+class TaskShowRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
-        return Auth::user()->can('update', $this->route('task'));
+        return Auth::user()->can('view', $this->route('task'));
     }
 
     /**
@@ -23,10 +23,7 @@ class TaskUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'task_category_id' => 'nullable|exists:task_categories,id',
-            'title' => 'string|max:255',
-            'description' => 'nullable|string|max:65535',
-            'due_date' => 'date',
-        ];
+                //
+            ];
     }
 }

--- a/app/Http/Requests/Transaction/TransactionDeleteRequest.php
+++ b/app/Http/Requests/Transaction/TransactionDeleteRequest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace App\Http\Requests\Task;
+namespace App\Http\Requests\Transaction;
 
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Http\FormRequest;
 
-class TaskUpdateRequest extends FormRequest
+class TransactionDeleteRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
-        return Auth::user()->can('update', $this->route('task'));
+        return Auth::user()->can('delete', $this->route('transaction'));
     }
 
     /**
@@ -23,10 +23,7 @@ class TaskUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'task_category_id' => 'nullable|exists:task_categories,id',
-            'title' => 'string|max:255',
-            'description' => 'nullable|string|max:65535',
-            'due_date' => 'date',
-        ];
+                //
+            ];
     }
 }

--- a/app/Http/Requests/Transaction/TransactionShowRequest.php
+++ b/app/Http/Requests/Transaction/TransactionShowRequest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace App\Http\Requests\Task;
+namespace App\Http\Requests\Transaction;
 
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Http\FormRequest;
 
-class TaskUpdateRequest extends FormRequest
+class TransactionShowRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
-        return Auth::user()->can('update', $this->route('task'));
+        return Auth::user()->can('view', $this->route('transaction'));
     }
 
     /**
@@ -23,10 +23,7 @@ class TaskUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'task_category_id' => 'nullable|exists:task_categories,id',
-            'title' => 'string|max:255',
-            'description' => 'nullable|string|max:65535',
-            'due_date' => 'date',
-        ];
+                //
+            ];
     }
 }

--- a/app/Http/Requests/Transaction/TransactionStoreRequest.php
+++ b/app/Http/Requests/Transaction/TransactionStoreRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Transaction;
 
+use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class TransactionStoreRequest extends FormRequest
@@ -24,8 +25,13 @@ class TransactionStoreRequest extends FormRequest
         return [
             'user_id' => 'exists:users,id',
             'bill_id' => 'exists:bills,id',
-            'transaction_category_id' =>
-                'nullable|exists:transaction_categories,id',
+            'transaction_category_id' => [
+                'required',
+                Rule::exists('transaction_categories', 'id')->where(
+                    'transaction_type',
+                    $this->type
+                ),
+            ],
             'amount' => 'required|numeric',
             'type' => 'string|in:income,expense',
             'description' => 'required|string|max:65535',

--- a/app/Http/Requests/Transaction/TransactionUpdateRequest.php
+++ b/app/Http/Requests/Transaction/TransactionUpdateRequest.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Requests\Transaction;
 
+use App\Models\Transaction;
+use Illuminate\Validation\Rule;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Foundation\Http\FormRequest;
 
 class TransactionUpdateRequest extends FormRequest
@@ -11,7 +14,7 @@ class TransactionUpdateRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return Auth::user()->can('update', $this->route('transaction'));
     }
 
     /**
@@ -24,8 +27,13 @@ class TransactionUpdateRequest extends FormRequest
         return [
             'user_id' => 'exists:users,id',
             'bill_id' => 'exists:bills,id',
-            'transaction_category_id' =>
-                'nullable|exists:transaction_categories,id',
+            'transaction_category_id' => [
+                'required',
+                Rule::exists('transaction_categories', 'id')->where(
+                    'transaction_type',
+                    $this->type
+                ),
+            ],
             'amount' => 'numeric',
             'type' => 'string|in:income,expense',
             'description' => 'string|max:65535',

--- a/app/Observers/BillObserver.php
+++ b/app/Observers/BillObserver.php
@@ -73,4 +73,22 @@ class BillObserver
             );
         }
     }
+
+    public function creating(Bill $bill): void
+    {
+        if ($bill->status === 'paid') {
+            $bill->paid_at = now();
+        }
+    }
+
+    public function updating(Bill $bill): void
+    {
+        if (
+            $bill->isDirty('status') &&
+            $bill->status === 'paid' &&
+            $bill->getOriginal('status') !== 'paid'
+        ) {
+            $bill->paid_at = now();
+        }
+    }
 }


### PR DESCRIPTION
All the business/authorization/validation logic that was in controllers is now on other places: Request Form and Observer classes.

Before, handling that the user only can temper/see with data they own it was in the controller methods. The same with a business logic related to bills. Now all the business is being dealt in observers (such as cache handling), and the validation in Request Form classes (even not-built-in ones, like the case with transactions: it can only be associated with a transaction_category of the same type (income/expense).

Also PHPDoc blocks have been added to controllers to make any developer who's seeing the controllers be aware that part of the logic of the application is in observers (the request are already explicit: type-hinting request objects in controller methods).