### PR TITLE
Refactor/show views improve design and navigation

### DIFF
--- a/app/Http/Controllers/BillController.php
+++ b/app/Http/Controllers/BillController.php
@@ -2,17 +2,18 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\Bill\BillDeleteRequest;
-use App\Http\Requests\Bill\BillShowRequest;
 use Auth;
 use App\Models\Bill;
 use Illuminate\Http\Request;
 use App\QueryOptions\Sort\Amount;
 use App\QueryOptions\Sort\DueDate;
 use App\QueryOptions\Filter\Status;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Pipeline;
+use App\Http\Requests\Bill\BillShowRequest;
 use App\Http\Requests\Bill\BillStoreRequest;
+use App\Http\Requests\Bill\BillDeleteRequest;
 use App\Http\Requests\Bill\BillUpdateRequest;
 
 /**
@@ -55,6 +56,9 @@ class BillController extends Controller
     {
         $bill->delete();
 
+        if (preg_match('/\/bills\/\d+$/', URL::previous())) {
+            return redirect()->route('bills.index');
+        }
         return redirect()->back();
     }
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -2,16 +2,17 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\Task\TaskDeleteRequest;
-use App\Http\Requests\Task\TaskShowRequest;
 use Auth;
 use App\Models\Task;
 use App\Models\TaskCategory;
 use App\QueryOptions\Sort\DueDate;
 use App\QueryOptions\Filter\Status;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Pipeline;
+use App\Http\Requests\Task\TaskShowRequest;
 use App\Http\Requests\Task\TaskStoreRequest;
+use App\Http\Requests\Task\TaskDeleteRequest;
 use App\Http\Requests\Task\TaskUpdateRequest;
 
 /**
@@ -56,6 +57,9 @@ class TaskController extends Controller
     {
         $task->delete();
 
+        if (preg_match('/\/tasks\/\d+$/', URL::previous())) {
+            return redirect()->route('tasks.index');
+        }
         return redirect()->back();
     }
 

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -2,18 +2,20 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\Transaction\TransactionDeleteRequest;
-use App\Http\Requests\Transaction\TransactionShowRequest;
 use Request;
 use App\Models\Transaction;
 use App\QueryOptions\Sort\Date;
 use App\QueryOptions\Filter\Type;
 use App\QueryOptions\Sort\Amount;
 use App\Models\TransactionCategory;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Pipeline;
+use App\Http\Requests\Transaction\TransactionShowRequest;
 use App\Http\Requests\Transaction\TransactionStoreRequest;
+use App\Http\Requests\Transaction\TransactionDeleteRequest;
 use App\Http\Requests\Transaction\TransactionUpdateRequest;
 
 class TransactionController extends Controller
@@ -61,6 +63,9 @@ class TransactionController extends Controller
     ) {
         $transaction->delete();
 
+        if (preg_match('/\/transactions\/\d+$/', URL::previous())) {
+            return redirect()->route('transactions.index');
+        }
         return redirect()->back();
     }
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -28,3 +28,11 @@ button {
 input[type='checkbox'] {
     @apply rounded-sm;
 }
+
+body::-webkit-scrollbar {
+    width: 10px;
+}
+body {
+    scrollbar-width: thin;
+    scrollbar-color: #e4aa70 transparent;
+}

--- a/resources/views/bills/show.blade.php
+++ b/resources/views/bills/show.blade.php
@@ -1,26 +1,74 @@
-<x-layout>
-    <h2>Bill Details</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Title</th>
-                <th>Description</th>
-                <th>Amount</th>
-                <th>Due Date</th>
-                <th>Status</th>
-                <th>Created At</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>{{ $bill->title }}</td>
-                <td>{{ $bill->description }}</td>
-                <td>{{ $bill->amount }}</td>
-                <td>{{ $bill->due_date->format('m-d-Y') }}</td>
-                <td>{{ $bill->status }}</td>
-                <td>{{ $bill->created_at->format('m-d-Y') }}</td>
-            </tr>
-        </tbody>
-    </table>
-</x-layout>
+<x-app-layout>
+    <x-slot name="header">
+    </x-slot>
 
+    <div
+        class="absolute w-3/4 transform -translate-x-1/2 -translate-y-1/2 rounded-md shadow-inner sm:w-3/4 md:w-2/4 top-1/2 left-1/2 bg-secondary-bg">
+        <div class="flex flex-col justify-center p-6">
+
+            <div class="mb-8">
+                <div class="flex items-center justify-between mb-2">
+                    <h2 class="text-4xl font-bold text-secondary-txt">Bill #{{ $bill->id }}</h2>
+                    <div class="flex items-center">
+                        <a href="{{ route('bills.edit', ['bill' => $bill]) }}"
+                            class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
+                                fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L12 21H7v-5L16.732 3.196a2.5 2.5 0 01-1.5-.964z" />
+                            </svg>
+                        </a>
+                        <form action="{{ route('bills.destroy', ['bill' => $bill]) }}" method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit"
+                                class="block rounded-full cursor-pointer hover:shadow-inner text-tertiary-txt hover:text-secondary-txt">
+                                <svg class="w-8 h-8 p-1 rounded-full hover:text-secondary-txt" fill="none"
+                                    stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16">
+                                    </path>
+                                </svg>
+                            </button>
+                        </form>
+                    </div>
+                </div>
+                <div class="overflow-auto break-all max-h-32">{{ $bill->description }}</div>
+            </div>
+
+            <div class="flex flex-col gap-3 [&>div>span]:text-tertiary-txt">
+
+                <div class="flex gap-2">
+                    <span>Title:</span>
+                    <div>{{ $bill->title }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Amount:</span>
+                    <div>{{ $bill->amount }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Category:</span>
+                    <div>{{ $bill->billCategory?->name ?? 'none' }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Status</span>
+                    <div>{{ $bill->status }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Created at:</span>
+                    <div>{{ $bill->created_at->format('m-d-Y') }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Due date:</span>
+                    <div>{{ $bill->due_date->format('m-d-Y') }}</div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -49,7 +49,7 @@
                 </header>
 
                 <!-- Page Content -->
-                <main class="px-4 sm:px-6 flex-1">
+                <main class="relative flex-1 px-4 sm:px-6">
                     {{ $slot }}
                 </main>
 

--- a/resources/views/tasks/show.blade.php
+++ b/resources/views/tasks/show.blade.php
@@ -1,22 +1,71 @@
-<h2>Task</h2>
-<table>
-    <thead>
-        <tr>
-            <th>Title</th>
-            <th>Description</th>
-            <th>Category</th>
-            <th>Due Date</th>
-            <th>Status</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{ $task->title }}</td>
-            <td>{{ $task->description }}</td>
-            <td>{{ $task->taskCategory?->name ?? 'none' }}</td>
-            <td>{{ $task->due_date->format('m-d-Y') }}</td>
-            <td>{{ $task->status }}</td>
-        </tr>
-    </tbody>
-</table>
+<x-app-layout>
+    <x-slot name="header">
+    </x-slot>
 
+    <div
+        class="absolute w-3/4 transform -translate-x-1/2 -translate-y-1/2 rounded-md shadow-inner sm:w-3/4 md:w-2/4 top-1/2 left-1/2 bg-secondary-bg">
+        <div class="flex flex-col justify-center p-6">
+
+            <div class="mb-8">
+                <div class="flex items-center justify-between mb-2">
+                    <h2 class="text-4xl font-bold text-secondary-txt">Task #{{ $task->id }}</h2>
+                    <div class="flex items-center">
+                        <a href="{{ route('tasks.edit', ['task' => $task]) }}"
+                            class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
+                                fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L12 21H7v-5L16.732 3.196a2.5 2.5 0 01-1.5-.964z" />
+                            </svg>
+                        </a>
+                        <form action="{{ route('tasks.destroy', ['task' => $task]) }}" method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit"
+                                class="block rounded-full cursor-pointer hover:shadow-inner text-tertiary-txt hover:text-secondary-txt">
+                                <svg class="w-8 h-8 p-1 rounded-full hover:text-secondary-txt" fill="none"
+                                    stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16">
+                                    </path>
+                                </svg>
+                            </button>
+                        </form>
+                    </div>
+                </div>
+                <div class="overflow-auto break-all max-h-32">
+                    <p>{{ $task->description }}</p>
+                </div>
+            </div>
+
+            <div class="flex flex-col gap-3 [&>div>span]:text-tertiary-txt">
+
+                <div class="flex gap-2">
+                    <span>Title:</span>
+                    <div>{{ $task->title }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Category:</span>
+                    <div>{{ $task->taskCategory?->name ?? 'none' }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Status</span>
+                    <div>{{ $task->status }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Created at:</span>
+                    <div>{{ $task->created_at->format('m-d-Y') }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Due date:</span>
+                    <div>{{ $task->due_date->format('m-d-Y') }}</div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/transactions/show.blade.php
+++ b/resources/views/transactions/show.blade.php
@@ -1,20 +1,65 @@
-<h2>Transactions</h2>
-<table>
-    <thead>
-        <tr>
-            <th>Amount</th>
-            <th>Type</th>
-            <th>Category</th>
-            <th>Date</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{ $transaction->amount }}</td>
-            <td>{{ $transaction->type }}</td>
-            <td>{{ $transaction->transactionCategory?->name ?? 'none' }}</td>
-            <td>{{ $transaction->created_at->format('m-d-Y') }}</td>
-        </tr>
-    </tbody>
-</table>
+<x-app-layout>
+    <x-slot name="header">
+    </x-slot>
 
+    <div
+        class="absolute w-3/4 transform -translate-x-1/2 -translate-y-1/2 rounded-md shadow-inner sm:w-3/4 md:w-2/4 top-1/2 left-1/2 bg-secondary-bg">
+        <div class="flex flex-col justify-center p-6">
+
+            <div class="mb-8">
+                <div class="flex items-center justify-between mb-2">
+                    <h2 class="text-4xl font-bold text-secondary-txt">Transaction #{{ $transaction->id }}</h2>
+                    <div class="flex items-center">
+                        <a href="{{ route('transactions.edit', ['transaction' => $transaction]) }}"
+                            class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
+                                fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L12 21H7v-5L16.732 3.196a2.5 2.5 0 01-1.5-.964z" />
+                            </svg>
+                        </a>
+                        <form action="{{ route('transactions.destroy', ['transaction' => $transaction]) }}"
+                            method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit"
+                                class="block rounded-full cursor-pointer hover:shadow-inner text-tertiary-txt hover:text-secondary-txt">
+                                <svg class="w-8 h-8 p-1 rounded-full hover:text-secondary-txt" fill="none"
+                                    stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16">
+                                    </path>
+                                </svg>
+                            </button>
+                        </form>
+                    </div>
+                </div>
+                <div class="overflow-auto break-all max-h-32">{{ $transaction->description }}</div>
+            </div>
+
+            <div class="flex flex-col gap-3 [&>div>span]:text-tertiary-txt">
+
+                <div class="flex gap-2">
+                    <span>Amount:</span>
+                    <div>{{ $transaction->amount }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Type:</span>
+                    <div>{{ $transaction->type }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Category:</span>
+                    <div>{{ $transaction->transactionCategory?->name ?? 'none' }}</div>
+                </div>
+
+                <div class="flex gap-2">
+                    <span>Made in:</span>
+                    <div>{{ $transaction->created_at->format('m-d-Y') }}</div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</x-app-layout>


### PR DESCRIPTION
The previous version was poor due to the removing of the start of deprecating layout.php and no navigating back option. All that has been improved in the newest version:

- App/layout.php being used as the parent view of show views replacing the previous layout.php, which includes the navbar and sidebar to improve user experience on navigation.
- Design has been changed and navigation was added to make possible for the user: to go to the edit route of the current model instance, or delete and navigate back to index route after that (controller method 'destroy' changed to conditionally determine the redirect based on the url the request was made from).
- custom scrollbar style applied to UI, considering situations such as when the user types a large description and the content of it needs to be overflown.
- main element in app/layout.php with position relative, making possible for positioning inner elements in inner views related to it.

![Screenshot_540](https://github.com/user-attachments/assets/52be48e1-70bf-4455-bbb7-e53488658fa9)
![Screenshot_541](https://github.com/user-attachments/assets/192f85ef-968c-4797-b87d-90146e6b14bf)

