### PR TITLE
Feature/cards for showing entities instances in index views

### DIFF
--- a/app/View/Components/CardIndex.php
+++ b/app/View/Components/CardIndex.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\View\Components;
+
+use Closure;
+use App\Models\Bill;
+use App\Models\Task;
+use App\Models\Transaction;
+use InvalidArgumentException;
+use Illuminate\View\Component;
+use Illuminate\Contracts\View\View;
+
+class CardIndex extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(
+        public string $entityName,
+        public $entityInstance
+    ) {
+        if (
+            !(
+                $entityInstance instanceof Transaction ||
+                $entityInstance instanceof Bill ||
+                $entityInstance instanceof Task
+            )
+        ) {
+            throw new InvalidArgumentException(
+                'Entity instance must be an instance of Transaction, Bill, or Task.'
+            );
+        }
+
+        $this->entityInstance = $entityInstance;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.card-index');
+    }
+}

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -225,5 +225,7 @@
     "Your bill \":title\" is due tomorrow.": "Sua conta \":title\" vence amanhã.",
     "View Bill": "Ver Conta",
     "Please make sure to pay it on time to avoid any late fees.": "Por favor, certifique-se de pagá-la a tempo para evitar quaisquer taxas de atraso.",
-    "If you have already paid this bill, no further action is required.": "Se você já pagou esta conta, nenhuma ação adicional é necessária."
+    "If you have already paid this bill, no further action is required.": "Se você já pagou esta conta, nenhuma ação adicional é necessária.",
+    "Paid": "Paga",
+    "Overdue": "Em Atraso"
 }

--- a/resources/views/bills/index.blade.php
+++ b/resources/views/bills/index.blade.php
@@ -43,12 +43,26 @@
                     <div class="form-group">
                         <p class="mb-1 text-secondary-txt">{{ __('Status') }}</p>
                         <div class="flex flex-col">
-                            <label
-                                class="inline-flex items-center cursor-pointer text-tertiary-txt hover:text-secondary-txt">
-                                <input type="checkbox" name="filterByStatus[]" value="pending"
+                            <label for="input-status-pending"
+                                class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
+                                <input type="checkbox" name="filterByStatus[]" id="input-status-pending" value="pending"
                                     class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
                                     {{ is_array(request('filterByStatus')) && in_array('pending', request('filterByStatus')) ? 'checked' : '' }}>
-                                <span class="ml-2 font-thin">{{ __('Pending') }}</span>
+                                <span class="ml-2">{{ __('Pending') }}</span>
+                            </label>
+                            <label for="input-status-paid"
+                                class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
+                                <input type="checkbox" name="filterByStatus[]" id="input-status-paid" value="paid"
+                                    class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
+                                    {{ is_array(request('filterByStatus')) && in_array('paid', request('filterByStatus')) ? 'checked' : '' }}>
+                                <span class="ml-2">{{ __('Paid') }}</span>
+                            </label>
+                            <label for="input-status-overdue"
+                                class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
+                                <input type="checkbox" name="filterByStatus[]" id="input-status-overdue" value="overdue"
+                                    class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
+                                    {{ is_array(request('filterByStatus')) && in_array('overdue', request('filterByStatus')) ? 'checked' : '' }}>
+                                <span class="ml-2">{{ __('Overdue') }}</span>
                             </label>
                         </div>
                     </div>
@@ -121,8 +135,9 @@
                                 </a>
                                 <a href="{{ route('bills.show', $bill) }}"
                                     class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
-                                        fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <svg xmlns="http://www.w3.org/2000/svg"
+                                        class="w-8 h-8 p-1 hover:text-secondary-txt" fill="none"
+                                        viewBox="0 0 24 24" stroke="currentColor">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                             d="M12 6a9.77 9.77 0 018.7 5.47c.2.38.2.82 0 1.2A9.77 9.77 0 0112 18a9.77 9.77 0 01-8.7-5.47 1.23 1.23 0 010-1.2A9.77 9.77 0 0112 6zm0 4a2 2 0 100 4 2 2 0 000-4z" />
                                     </svg>

--- a/resources/views/bills/index.blade.php
+++ b/resources/views/bills/index.blade.php
@@ -75,78 +75,18 @@
     </form>
 
     @if ($bills->isNotEmpty())
-        <div class="w-full overflow-x-auto rounded-lg">
-            <table class="w-full divide-y divide-gray-200">
-                <thead class="bg-secondary-bg">
-                    <tr>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Amount') }}
-                        </th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Title') }}
-                        </th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Description') }}
-                        </th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Date') }}
-                        </th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Status') }}
-                        </th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-center uppercase text-primary-txt">
-                            {{ __('Actions') }}
-                        </th>
-                    </tr>
-                </thead>
-                <tbody class="bg-tertiary-bg">
-                    @foreach ($bills as $bill)
-                        <tr
-                            class="{{ $loop->iteration % 2 == 0 ? 'text-tertiary-txt bg-secondary-bg' : 'text-secondary-txt bg-tertiary-bg' }}">
-                            <td class="p-3 font-semibold whitespace-nowrap">{{ $bill->amount }}</td>
-                            <td class="p-3 font-normal whitespace-nowrap">{{ $bill->title }}</td>
-                            <td class="p-3 font-normal whitespace-nowrap">
-                                {{ Str::limit($bill->description, 20, '...') }}</td>
-                            <td class="p-3 font-normal whitespace-nowrap">
-                                {{ $bill->due_date->format('Y-m-d') }}</td>
-                            <td class="p-3 font-normal whitespace-nowrap">{{ $bill->status }}</td>
-                            <td class="flex items-center justify-center p-3 font-normal whitespace-nowrap">
-                                <form action="{{ route('bills.destroy', $bill) }}" method="POST">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit"
-                                        class="block rounded-full cursor-pointer hover:shadow-inner text-tertiary-txt hover:text-secondary-txt">
-                                        <svg class="w-8 h-8 p-1 rounded-full hover:text-secondary-txt" fill="none"
-                                            stroke="currentColor" viewBox="0 0 24 24"
-                                            xmlns="http://www.w3.org/2000/svg">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16">
-                                            </path>
-                                        </svg>
-                                    </button>
-                                </form>
-                                <a href="{{ route('bills.edit', $bill) }}"
-                                    class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
-                                        fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                            d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L12 21H7v-5L16.732 3.196a2.5 2.5 0 01-1.5-.964z" />
-                                    </svg>
-                                </a>
-                                <a href="{{ route('bills.show', $bill) }}"
-                                    class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
-                                    <svg xmlns="http://www.w3.org/2000/svg"
-                                        class="w-8 h-8 p-1 hover:text-secondary-txt" fill="none"
-                                        viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                            d="M12 6a9.77 9.77 0 018.7 5.47c.2.38.2.82 0 1.2A9.77 9.77 0 0112 18a9.77 9.77 0 01-8.7-5.47 1.23 1.23 0 010-1.2A9.77 9.77 0 0112 6zm0 4a2 2 0 100 4 2 2 0 000-4z" />
-                                    </svg>
-                                </a>
-                            </td>
-                        </tr>
-                    @endforeach
-                </tbody>
-            </table>
+        <div class="grid grid-cols-2 gap-4">
+            @foreach ($bills as $bill)
+                <x-card-index :entityInstance="$bill" :entityName="'bill'">
+                    @if ($bill->status === 'pending')
+                        <x-heroicon-o-clock class="w-6 h-6 text-yellow-500" />
+                    @elseif ($bill->status === 'paid')
+                        <x-heroicon-o-check-circle class="w-6 h-6 text-green-500" />
+                    @else
+                        <x-heroicon-o-exclamation-circle class="w-6 h-6 text-red-500" />
+                    @endif
+                </x-card-index>
+            @endforeach
         </div>
     @else
         <div class="flex items-center justify-center h-40">

--- a/resources/views/components/card-index.blade.php
+++ b/resources/views/components/card-index.blade.php
@@ -1,0 +1,48 @@
+@props(['entityInstance', 'entityName'])
+
+<div class="rounded-md shadow-inner bg-secondary-bg">
+    <div class="flex flex-col justify-center px-6 py-4">
+        <div class="mb-8">
+            <div class="flex items-center justify-between">
+                <div>
+                    <div class="flex items-center">
+                        <a class="mr-2" href="{{ route($entityName . 's.show', $entityInstance) }}">
+                            <h3
+                                class="max-w-full text-2xl font-bold break-words text-tertiary-txt hover:underline hover:text-secondary-txt title">
+                                {{ Str::limit($entityInstance->title, 30, '...') ?? 'Placeholder Title' }}
+                            </h3>
+                        </a>
+                        {{ $slot }}
+                    </div>
+                </div>
+                <div class="flex items-center">
+                    <form action="{{ route($entityName . 's.destroy', $entityInstance) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit"
+                            class="block rounded-full cursor-pointer hover:shadow-inner text-tertiary-txt hover:text-secondary-txt">
+                            <svg class="w-8 h-8 p-1 rounded-full hover:text-secondary-txt" fill="none"
+                                stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16">
+                                </path>
+                            </svg>
+                        </button>
+                    </form>
+                    <a href="{{ route($entityName . 's.edit', $entityInstance) }}"
+                        class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
+                            fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L12 21H7v-5L16.732 3.196a2.5 2.5 0 01-1.5-.964z" />
+                        </svg>
+                    </a>
+                </div>
+            </div>
+
+            <div class="overflow-auto font-thin break-all text-primary-txt max-h-32">
+                <p>{{ Str::limit($entityInstance->description, 120, '...') ?? 'No description available' }}</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -61,69 +61,18 @@
     </form>
 
     @if ($tasks->isNotEmpty())
-        <div class="w-full overflow-x-auto rounded-lg">
-            <table class="w-full divide-y divide-gray-200">
-                <thead class="bg-secondary-bg">
-                    <tr>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Category') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Status') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Title') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Description') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Due Date') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Actions') }}</th>
-                    </tr>
-                </thead>
-                <tbody class="bg-tertiary-bg">
-                    @foreach ($tasks as $task)
-                        <tr
-                            class="{{ $loop->iteration % 2 == 0 ? 'text-tertiary-txt bg-secondary-bg' : 'text-secondary-txt bg-tertiary-bg' }}">
-                            <td class="p-3">{{ $task->taskCategory?->name ?? __('none') }}</td>
-                            <td class="p-3">{{ $task->status }}</td>
-                            <td class="p-3">{{ $task->title }}</td>
-                            <td class="p-3">{{ Str::limit($task->description, 20, '...') }}</td>
-                            <td class="p-3">{{ $task->due_date->format('m-d-Y') }}</td>
-                            <td class="flex items-center justify-center p-3 whitespace-nowrap">
-                                <form action="{{ route('tasks.destroy', ['task' => $task]) }}" method="POST">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit"
-                                        class="block rounded-full cursor-pointer hover:shadow-inner text-tertiary-txt hover:text-secondary-txt">
-                                        <svg class="w-8 h-8 p-1 rounded-full hover:text-secondary-txt" fill="none"
-                                            stroke="currentColor" viewBox="0 0 24 24"
-                                            xmlns="http://www.w3.org/2000/svg">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16">
-                                            </path>
-                                        </svg>
-                                    </button>
-                                </form>
-                                <a href="{{ route('tasks.edit', ['task' => $task]) }}"
-                                    class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
-                                        fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                            d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L12 21H7v-5L16.732 3.196a2.5 2.5 0 01-1.5-.964z" />
-                                    </svg>
-                                </a>
-                                <a href="{{ route('tasks.show', $task) }}"
-                                    class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
-                                        fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                            d="M12 6a9.77 9.77 0 018.7 5.47c.2.38.2.82 0 1.2A9.77 9.77 0 0112 18a9.77 9.77 0 01-8.7-5.47 1.23 1.23 0 010-1.2A9.77 9.77 0 0112 6zm0 4a2 2 0 100 4 2 2 0 000-4z" />
-                                    </svg>
-                                </a>
-                            </td>
-                        </tr>
-                    @endforeach
-                </tbody>
-            </table>
+        <div class="grid grid-cols-2 gap-4">
+            @foreach ($tasks as $task)
+                <x-card-index :entityInstance="$task" :entityName="'task'">
+                    @if ($task->status === 'pending')
+                        <x-heroicon-o-clock class="w-6 h-6 text-yellow-500" />
+                    @elseif ($task->status === 'completed')
+                        <x-heroicon-o-check-circle class="w-6 h-6 text-green-500" />
+                    @else
+                        <x-heroicon-o-x-circle class="w-6 h-6 text-red-500" />
+                    @endif
+                </x-card-index>
+            @endforeach
         </div>
     @else
         <div class="flex items-center justify-center h-40">

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -29,29 +29,29 @@
                 <div class="form-group">
                     <p class="mb-1 text-secondary-txt">{{ __('Status:') }}</p>
                     <div class="flex flex-col">
-                        <label
-                            class="inline-flex items-center cursor-pointer text-tertiary-txt hover:text-secondary-txt">
-                            <input type="checkbox" name="filterByStatus[]" id="filterByStatusPending" value="pending"
+                        <label for="input-status-pending"
+                            class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
+                            <input type="checkbox" name="filterByStatus[]" id="input-status-pending" value="pending"
                                 class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
                                 {{ is_array(request('filterByStatus')) && in_array('pending', request('filterByStatus')) ? 'checked' : '' }}>
-                            <span class="ml-2 font-thin">{{ __('Pending') }}</span>
+                            <span class="ml-2">{{ __('Pending') }}</span>
                         </label>
-                        <label
-                            class="inline-flex items-center cursor-pointer text-tertiary-txt hover:text-secondary-txt">
-                            <input type="checkbox" name="filterByStatus[]" id="filterByStatusCompleted"
-                                value="completed"
+                        <label for="input-status-completed"
+                            class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
+                            <input type="checkbox" name="filterByStatus[]" id="input-status-completed" value="completed"
                                 class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
                                 {{ is_array(request('filterByStatus')) && in_array('completed', request('filterByStatus')) ? 'checked' : '' }}>
-                            <span class="ml-2 font-thin">{{ __('Completed') }}</span>
+                            <span class="ml-2">{{ __('Completed') }}</span>
                         </label>
-                        <label
-                            class="inline-flex items-center cursor-pointer text-tertiary-txt hover:text-secondary-txt">
-                            <input type="checkbox" name="filterByStatus[]" id="filterByStatusFailed" value="failed"
+                        <label for="input-status-failed"
+                            class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
+                            <input type="checkbox" name="filterByStatus[]" id="input-status-failed" value="failed"
                                 class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
                                 {{ is_array(request('filterByStatus')) && in_array('failed', request('filterByStatus')) ? 'checked' : '' }}>
-                            <span class="ml-2 font-thin">{{ __('Failed') }}</span>
+                            <span class="ml-2">{{ __('Failed') }}</span>
                         </label>
                     </div>
+
                 </div>
             </div>
 

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -65,74 +65,16 @@
     </form>
 
     @if ($transactions->isNotEmpty())
-        <div class="w-full overflow-x-auto rounded-lg">
-            <table class="w-full divide-y divide-gray-200">
-                <thead class="bg-secondary-bg">
-                    <tr>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Amount') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Type') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Category') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Description') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-left uppercase text-primary-txt">
-                            {{ __('Date') }}</th>
-                        <th class="p-3 text-xs font-medium tracking-wider text-center uppercase text-primary-txt">
-                            {{ __('Action') }}</th>
-                    </tr>
-                </thead>
-                <tbody class="bg-tertiary-bg">
-                    @foreach ($transactions as $transaction)
-                        <tr
-                            class="{{ $loop->iteration % 2 == 0 ? 'text-tertiary-txt bg-secondary-bg' : 'text-secondary-txt bg-tertiary-bg' }}">
-                            <td class="p-3 font-semibold whitespace-nowrap">{{ $transaction->amount }}</td>
-                            <td class="p-3 font-normal whitespace-nowrap">{{ $transaction->type }}</td>
-                            <td class="p-3 font-normal whitespace-nowrap">
-                                {{ $transaction->transactionCategory?->name ?? __('none') }}</td>
-                            <td class="p-3 font-normal whitespace-nowrap">
-                                {{ Str::limit($transaction->description, 20, '...') }}</td>
-                            <td class="p-3 font-normal whitespace-nowrap">
-                                {{ $transaction->created_at->format('m-d-Y') }}
-                            </td>
-                            <td class="flex items-center justify-center p-3 font-normal whitespace-nowrap">
-                                <form action="{{ route('transactions.destroy', ['transaction' => $transaction]) }}"
-                                    method="POST">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit"
-                                        class="block rounded-full cursor-pointer hover:shadow-inner text-tertiary-txt hover:text-secondary-txt">
-                                        <svg class="w-8 h-8 p-1 rounded-full hover:text-secondary-txt" fill="none"
-                                            stroke="currentColor" viewBox="0 0 24 24"
-                                            xmlns="http://www.w3.org/2000/svg">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16">
-                                            </path>
-                                        </svg>
-                                    </button>
-                                </form>
-                                <a href="{{ route('transactions.edit', ['transaction' => $transaction]) }}"
-                                    class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
-                                        fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                            d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L12 21H7v-5L16.732 3.196a2.5 2.5 0 01-1.5-.964z" />
-                                    </svg>
-                                </a>
-                                <a href="{{ route('transactions.show', $transaction) }}"
-                                    class="block rounded-full text-tertiary-txt hover:shadow-inner hover:text-secondary-txt">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 p-1 hover:text-secondary-txt"
-                                        fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                            d="M12 6a9.77 9.77 0 018.7 5.47c.2.38.2.82 0 1.2A9.77 9.77 0 0112 18a9.77 9.77 0 01-8.7-5.47 1.23 1.23 0 010-1.2A9.77 9.77 0 0112 6zm0 4a2 2 0 100 4 2 2 0 000-4z" />
-                                    </svg>
-                                </a>
-                            </td>
-                        </tr>
-                    @endforeach
-                </tbody>
-            </table>
+        <div class="grid grid-cols-2 gap-4">
+            @foreach ($transactions as $transaction)
+                <x-card-index :entityInstance="$transaction" :entityName="'transaction'">
+                    @if ($transaction->type === 'income')
+                        <x-heroicon-o-trending-up class="w-6 h-6 text-green-500" />
+                    @else
+                        <x-heroicon-o-trending-down class="w-6 h-6 text-red-500" />
+                    @endif
+                </x-card-index>
+            @endforeach
         </div>
     @else
         <div class="flex items-center justify-center h-40">

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -40,19 +40,19 @@
                     <div class="form-group">
                         <p class="mb-1 text-secondary-txt">{{ __('Type') }}</p>
                         <div class="flex flex-col">
-                            <label
-                                class="inline-flex items-center cursor-pointer text-tertiary-txt hover:text-secondary-txt">
-                                <input type="checkbox" name="filterByType" value="income"
+                            <label for="input-type-income"
+                                class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
+                                <input type="checkbox" name="filterByType" id="input-type-income" value="income"
                                     class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
                                     {{ request('filterByType') == 'income' ? 'checked' : '' }}>
-                                <span class="ml-2 font-thin">{{ __('Income') }}</span>
+                                <span class="ml-2">{{ __('Income') }}</span>
                             </label>
-                            <label
-                                class="inline-flex items-center cursor-pointer text-tertiary-txt hover:text-secondary-txt">
-                                <input type="checkbox" name="filterByType" value="expense"
+                            <label for="input-type-expense"
+                                class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
+                                <input type="checkbox" name="filterByType" id="input-type-expense" value="expense"
                                     class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
                                     {{ request('filterByType') == 'expense' ? 'checked' : '' }}>
-                                <span class="ml-2 font-light">{{ __('Expense') }}</span>
+                                <span class="ml-2">{{ __('Expense') }}</span>
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
- The entities instances were previously shown as rows from a table in index views, now they're shown as cards with some of the attributes common to them: title and description - except Transaction that does not yet have 'title'. 

- Navigation on seeing each entity instance individually, editing and deleting is guaranteed. 

- The cards have a slot to place an icon indicating an specificity of the entity instance (transaction -> type, bill -> status, task -> status).

now
![Screenshot_551](https://github.com/user-attachments/assets/3dfb6eae-1374-49f6-93ea-dcd1b3161d96)
![Screenshot_550](https://github.com/user-attachments/assets/dbe2a920-6e39-40e9-938c-0f0ce6452d9c)
![Screenshot_552](https://github.com/user-attachments/assets/8f527df0-a970-4213-8dbb-64b4a3309296)

before
![Screenshot_553](https://github.com/user-attachments/assets/9b315390-4f3f-4e9a-8273-2b8201943a74)