### PR TITLE
Refactor/query options explicitly passed to views by index methods and always as arrays

### DIFF
--- a/app/Http/Controllers/BillController.php
+++ b/app/Http/Controllers/BillController.php
@@ -30,14 +30,31 @@ class BillController extends Controller
 
     public function index(Request $request)
     {
+        $filterByStatus = $request->input('filterByStatus') ?? [];
+        $sortByAmount = $request->input('sortByAmount');
+        $sortByDueDate = $request->input('sortByDueDate');
+
         $query = Auth::user()->bills()->getQuery();
 
         $bills = Pipeline::send($query)
-            ->through([DueDate::class, Amount::class, Status::class])
+            ->through([
+                function ($query, $next) use ($filterByStatus) {
+                    return (new Status($filterByStatus))->handle($query, $next);
+                },
+                function ($query, $next) use ($sortByAmount) {
+                    return (new Amount($sortByAmount))->handle($query, $next);
+                },
+                function ($query, $next) use ($sortByDueDate) {
+                    return (new DueDate($sortByDueDate))->handle($query, $next);
+                },
+            ])
             ->thenReturn()
             ->paginate(10);
 
-        return view('bills.index', compact('bills'));
+        return view(
+            'bills.index',
+            compact('bills', 'filterByStatus', 'sortByAmount', 'sortByDueDate')
+        );
     }
 
     public function show(BillShowRequest $request, Bill $bill)

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -14,6 +14,7 @@ use App\Http\Requests\Task\TaskShowRequest;
 use App\Http\Requests\Task\TaskStoreRequest;
 use App\Http\Requests\Task\TaskDeleteRequest;
 use App\Http\Requests\Task\TaskUpdateRequest;
+use Illuminate\Http\Request;
 
 /**
  * @see \App\Observers\TaskObserver
@@ -27,16 +28,29 @@ class TaskController extends Controller
         return redirect()->back();
     }
 
-    public function index()
+    public function index(Request $request)
     {
+        $filterByStatus = $request->input('filterByStatus') ?? [];
+        $sortByDueDate = $request->input('sortByDueDate');
+
         $query = Auth::user()->tasks()->getQuery();
 
         $tasks = Pipeline::send($query)
-            ->through([DueDate::class, Status::class])
+            ->through([
+                function ($query, $next) use ($filterByStatus) {
+                    return (new Status($filterByStatus))->handle($query, $next);
+                },
+                function ($query, $next) use ($sortByDueDate) {
+                    return (new DueDate($sortByDueDate))->handle($query, $next);
+                },
+            ])
             ->thenReturn()
             ->paginate(10);
 
-        return view('tasks.index', compact('tasks'));
+        return view(
+            'tasks.index',
+            compact('tasks', 'filterByStatus', 'sortByDueDate')
+        );
     }
 
     public function show(TaskShowRequest $request, Task $task)

--- a/app/QueryOptions/Filter/Status.php
+++ b/app/QueryOptions/Filter/Status.php
@@ -4,16 +4,17 @@ namespace App\QueryOptions\Filter;
 
 class Status
 {
+    private $filterByStatus;
+
+    public function __construct($filterByStatus)
+    {
+        $this->filterByStatus = $filterByStatus;
+    }
+
     public function handle($query, $next)
     {
-        if (request()->has('filterByStatus')) {
-            $filterByStatus = request()->input('filterByStatus');
-
-            if (is_array($filterByStatus)) {
-                $query->whereIn('status', $filterByStatus);
-            } else {
-                $query->where('status', $filterByStatus);
-            }
+        if (!empty($this->filterByStatus)) {
+            $query->whereIn('status', $this->filterByStatus);
         }
 
         return $next($query);

--- a/app/QueryOptions/Filter/Type.php
+++ b/app/QueryOptions/Filter/Type.php
@@ -4,12 +4,17 @@ namespace App\QueryOptions\Filter;
 
 class Type
 {
+    private $filterByType;
+
+    public function __construct($filterByType)
+    {
+        $this->filterByType = $filterByType;
+    }
+
     public function handle($query, $next)
     {
-        if (request()->has('filterByType')) {
-            $filterByType = request()->input('filterByType');
-
-            $query->where('type', $filterByType);
+        if (!empty($this->filterByType)) {
+            $query->whereIn('type', $this->filterByType);
         }
 
         return $next($query);

--- a/app/QueryOptions/Sort/Amount.php
+++ b/app/QueryOptions/Sort/Amount.php
@@ -4,13 +4,17 @@ namespace App\QueryOptions\Sort;
 
 class Amount
 {
+    private $sortByAmount;
+
+    public function __construct($sortByAmount)
+    {
+        $this->sortByAmount = $sortByAmount;
+    }
+
     public function handle($query, $next)
     {
-        if (request()->has('sortByAmount')) {
-            $sortByAmount = request()->input('sortByAmount');
-
-            ($sortByAmount === 'asc' || $sortByAmount === 'desc') &&
-                $query->orderBy('amount', $sortByAmount);
+        if ($this->sortByAmount === 'asc' || $this->sortByAmount === 'desc') {
+            $query->orderBy('amount', $this->sortByAmount);
         }
 
         return $next($query);

--- a/app/QueryOptions/Sort/Date.php
+++ b/app/QueryOptions/Sort/Date.php
@@ -4,13 +4,17 @@ namespace App\QueryOptions\Sort;
 
 class Date
 {
+    private $sortByDate;
+
+    public function __construct($sortByDate)
+    {
+        $this->sortByDate = $sortByDate;
+    }
+
     public function handle($query, $next)
     {
-        if (request()->has('sortByDate')) {
-            $sortByDate = request()->input('sortByDate');
-
-            ($sortByDate === 'asc' || $sortByDate === 'desc') &&
-                $query->orderBy('created_at', $sortByDate);
+        if ($this->sortByDate === 'asc' || $this->sortByDate === 'desc') {
+            $query->orderBy('created_at', $this->sortByDate);
         }
 
         return $next($query);

--- a/app/QueryOptions/Sort/DueDate.php
+++ b/app/QueryOptions/Sort/DueDate.php
@@ -4,13 +4,17 @@ namespace App\QueryOptions\Sort;
 
 class DueDate
 {
+    private $sortByDueDate;
+
+    public function __construct($sortByDueDate)
+    {
+        $this->sortByDueDate = $sortByDueDate;
+    }
+
     public function handle($query, $next)
     {
-        if (request()->has('sortByDueDate')) {
-            $sortByDueDate = request()->input('sortByDueDate');
-
-            ($sortByDueDate === 'asc' || $sortByDueDate === 'desc') &&
-                $query->orderBy('due_date', $sortByDueDate);
+        if ($this->sortByDueDate === 'asc' || $this->sortByDueDate === 'desc') {
+            $query->orderBy('due_date', $this->sortByDueDate);
         }
 
         return $next($query);

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -230,5 +230,6 @@
     "Overdue": "Em Atraso",
     "Table view": "Visualização tabela",
     "category": "categoria",
-    "bill": "conta"
+    "bill": "conta",
+    "Select": "Selecionar"
 }

--- a/resources/views/bills/index.blade.php
+++ b/resources/views/bills/index.blade.php
@@ -14,6 +14,9 @@
                     <p class="mb-1 text-secondary-txt">{{ __('Amount') }}</p>
                     <select name="sortByAmount"
                         class="font-thin border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg">
+                        <option class="font-thin" value="">
+                            {{ __('Select') }}
+                        </option>
                         <option class="font-thin" value="asc" {{ $sortByAmount == 'asc' ? 'selected' : '' }}>
                             {{ __('Ascending') }}
                         </option>
@@ -27,6 +30,9 @@
                     <p class="mb-1 text-secondary-txt">{{ __('Due Date') }}</p>
                     <select name="sortByDueDate"
                         class="font-thin border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg">
+                        <option class="font-thin" value="">
+                            {{ __('Select') }}
+                        </option>
                         <option class="font-thin" value="asc" {{ $sortByDueDate == 'asc' ? 'selected' : '' }}>
                             {{ __('Ascending') }}
                         </option>

--- a/resources/views/bills/index.blade.php
+++ b/resources/views/bills/index.blade.php
@@ -14,11 +14,11 @@
                     <p class="mb-1 text-secondary-txt">{{ __('Amount') }}</p>
                     <select name="sortByAmount"
                         class="font-thin border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg">
-                        <option class="font-thin" value="asc"
-                            {{ request('sortByAmount') == 'asc' ? 'selected' : '' }}>{{ __('Ascending') }}
+                        <option class="font-thin" value="asc" {{ $sortByAmount == 'asc' ? 'selected' : '' }}>
+                            {{ __('Ascending') }}
                         </option>
-                        <option class="font-thin" value="desc"
-                            {{ request('sortByAmount') == 'desc' ? 'selected' : '' }}>{{ __('Descending') }}
+                        <option class="font-thin" value="desc" {{ $sortByAmount == 'desc' ? 'selected' : '' }}>
+                            {{ __('Descending') }}
                         </option>
                     </select>
                 </div>
@@ -27,11 +27,11 @@
                     <p class="mb-1 text-secondary-txt">{{ __('Due Date') }}</p>
                     <select name="sortByDueDate"
                         class="font-thin border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg">
-                        <option class="font-thin" value="asc"
-                            {{ request('sortByDueDate') == 'asc' ? 'selected' : '' }}>{{ __('Ascending') }}
+                        <option class="font-thin" value="asc" {{ $sortByDueDate == 'asc' ? 'selected' : '' }}>
+                            {{ __('Ascending') }}
                         </option>
-                        <option class="font-thin" value="desc"
-                            {{ request('sortByDueDate') == 'desc' ? 'selected' : '' }}>{{ __('Descending') }}
+                        <option class="font-thin" value="desc" {{ $sortByDueDate == 'desc' ? 'selected' : '' }}>
+                            {{ __('Descending') }}
                         </option>
                     </select>
                 </div>
@@ -47,21 +47,21 @@
                                 class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
                                 <input type="checkbox" name="filterByStatus[]" id="input-status-pending" value="pending"
                                     class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
-                                    {{ is_array(request('filterByStatus')) && in_array('pending', request('filterByStatus')) ? 'checked' : '' }}>
+                                    {{ in_array('pending', $filterByStatus) ? 'checked' : '' }}>
                                 <span class="ml-2">{{ __('Pending') }}</span>
                             </label>
                             <label for="input-status-paid"
                                 class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
                                 <input type="checkbox" name="filterByStatus[]" id="input-status-paid" value="paid"
                                     class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
-                                    {{ is_array(request('filterByStatus')) && in_array('paid', request('filterByStatus')) ? 'checked' : '' }}>
+                                    {{ in_array('paid', $filterByStatus) ? 'checked' : '' }}>
                                 <span class="ml-2">{{ __('Paid') }}</span>
                             </label>
                             <label for="input-status-overdue"
                                 class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
                                 <input type="checkbox" name="filterByStatus[]" id="input-status-overdue" value="overdue"
                                     class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
-                                    {{ is_array(request('filterByStatus')) && in_array('overdue', request('filterByStatus')) ? 'checked' : '' }}>
+                                    {{ in_array('overdue', $filterByStatus) ? 'checked' : '' }}>
                                 <span class="ml-2">{{ __('Overdue') }}</span>
                             </label>
                         </div>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -14,6 +14,9 @@
                     <p class="mb-1 text-secondary-txt">{{ __('Due date:') }}</p>
                     <select name="sortByDueDate"
                         class="font-thin border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg">
+                        <option class="font-thin" value="">
+                            {{ __('Select') }}
+                        </option>
                         <option id="sortByDueDateAsc" value="asc"
                             class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
                             {{ request('sortByDueDate') == 'asc' ? 'selected' : '' }}>{{ __('Ascending') }}</option>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -33,21 +33,21 @@
                             class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
                             <input type="checkbox" name="filterByStatus[]" id="input-status-pending" value="pending"
                                 class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
-                                {{ is_array(request('filterByStatus')) && in_array('pending', request('filterByStatus')) ? 'checked' : '' }}>
+                                {{ in_array('pending', $filterByStatus) ? 'checked' : '' }}>
                             <span class="ml-2">{{ __('Pending') }}</span>
                         </label>
                         <label for="input-status-completed"
                             class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
                             <input type="checkbox" name="filterByStatus[]" id="input-status-completed" value="completed"
                                 class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
-                                {{ is_array(request('filterByStatus')) && in_array('completed', request('filterByStatus')) ? 'checked' : '' }}>
+                                {{ in_array('completed', $filterByStatus) ? 'checked' : '' }}>
                             <span class="ml-2">{{ __('Completed') }}</span>
                         </label>
                         <label for="input-status-failed"
                             class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
                             <input type="checkbox" name="filterByStatus[]" id="input-status-failed" value="failed"
                                 class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
-                                {{ is_array(request('filterByStatus')) && in_array('failed', request('filterByStatus')) ? 'checked' : '' }}>
+                                {{ in_array('failed', $filterByStatus) ? 'checked' : '' }}>
                             <span class="ml-2">{{ __('Failed') }}</span>
                         </label>
                     </div>

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -42,16 +42,16 @@
                         <div class="flex flex-col">
                             <label for="input-type-income"
                                 class="inline-flex items-center font-thin cursor-pointer text-tertiary-txt hover:text-secondary-txt">
-                                <input type="checkbox" name="filterByType" id="input-type-income" value="income"
+                                <input type="checkbox" name="filterByType[]" id="input-type-income" value="income"
                                     class="border-0 cursor-pointer input-type focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
-                                    {{ request('filterByType') == 'income' ? 'checked' : '' }}>
+                                    {{ in_array('income', $filterByType) ? 'checked' : '' }}>
                                 <span class="ml-2">{{ __('Income') }}</span>
                             </label>
                             <label for="input-type-expense"
                                 class="inline-flex items-center font-thin cursor-pointer input-type text-tertiary-txt hover:text-secondary-txt">
-                                <input type="checkbox" name="filterByType" id="input-type-expense" value="expense"
+                                <input type="checkbox" name="filterByType[]" id="input-type-expense" value="expense"
                                     class="border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg"
-                                    {{ request('filterByType') == 'expense' ? 'checked' : '' }}>
+                                    {{ in_array('expense', $filterByType) ? 'checked' : '' }}>
                                 <span class="ml-2">{{ __('Expense') }}</span>
                             </label>
                         </div>

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -14,6 +14,9 @@
                     <p class="mb-1 text-secondary-txt">{{ __('Amount') }}</p>
                     <select name="sortByAmount"
                         class="font-thin border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg">
+                        <option class="font-thin" value="">
+                            {{ __('Select') }}
+                        </option>
                         <option class="font-thin" value="asc"
                             {{ request('sortByAmount') == 'asc' ? 'selected' : '' }}>{{ __('Ascending') }}</option>
                         <option class="font-thin" value="desc"
@@ -25,6 +28,9 @@
                     <p class="mb-1 text-secondary-txt">{{ __('Date') }}</p>
                     <select name="sortByDate"
                         class="font-thin border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-quinary-bg text-tertiary-txt bg-secondary-bg hover:bg-tertiary-bg focus:bg-tertiary-bg">
+                        <option class="font-thin" value="">
+                            {{ __('Select') }}
+                        </option>
                         <option class="font-thin" value="asc"
                             {{ request('sortByDate') == 'asc' ? 'selected' : '' }}>
                             {{ __('Ascending') }}</option>


### PR DESCRIPTION
The 'index' method in transaction/bill/task controller didn't sent before any query options to index views: the 'filter/sortBy' values being used in QueryOption classes and in the index views was coming directly from the request, and the values, especially of 'filterBy', were not consistent: if just one checkbox 'filterBy' was selected, the value passed to the request would be primitive; if more, then it would be an array: that difference was considered both in QueryOption and views. 

- Now the filterBy is always an array, providing more consistency, less code *in general* without damaging readability - in general because the controller size increased, but at least the approach more straightforwardly informs the developer which filters and sorts are applied to the view. The ideia of refactoring this way came from filtering, but also on sorting the same logic has been applied to enforce code consistency.

- As a plus, the selects in index view got default values due to the fact that even without selecting manually anything, the first option available is automatically selected, and then clicking on 'apply' would trigger sorting not desired by the end user.

![Screenshot_556](https://github.com/user-attachments/assets/04992ba1-dceb-400a-9c5d-2ffee2299863)