### PR TITLE
Feature/make bills able to be paid outside edit view

### DIFF
--- a/app/Http/Controllers/BillController.php
+++ b/app/Http/Controllers/BillController.php
@@ -47,8 +47,21 @@ class BillController extends Controller
 
     public function update(BillUpdateRequest $request, Bill $bill)
     {
+        $originalBillStatus = $bill->status;
+
         $bill->update($request->validated());
 
+        if (
+            $request->validated('status') === 'paid' &&
+            $originalBillStatus !== 'paid'
+        ) {
+            $request
+                ->session()
+                ->flash(
+                    'success',
+                    __("Bill status changed to 'paid' successfully!")
+                );
+        }
         return redirect()->back();
     }
 

--- a/app/Http/Requests/Bill/BillStoreRequest.php
+++ b/app/Http/Requests/Bill/BillStoreRequest.php
@@ -25,6 +25,7 @@ class BillStoreRequest extends FormRequest
             'title' => 'required|string|max:255',
             'description' => 'nullable|string|max:65535',
             'amount' => 'numeric',
+            'status' => 'in:pending,paid,overdue',
             'due_date' => 'required|date',
         ];
     }

--- a/app/Http/Requests/Bill/BillUpdateRequest.php
+++ b/app/Http/Requests/Bill/BillUpdateRequest.php
@@ -23,10 +23,10 @@ class BillUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'title' => 'string|max:255',
+            'title' => 'nullable|string|max:255',
             'description' => 'nullable|string|max:65535',
-            'amount' => 'numeric',
-            'due_date' => 'date',
+            'amount' => 'nullable|numeric',
+            'due_date' => 'nullable|date',
         ];
     }
 }

--- a/app/Http/Requests/Bill/BillUpdateRequest.php
+++ b/app/Http/Requests/Bill/BillUpdateRequest.php
@@ -26,6 +26,7 @@ class BillUpdateRequest extends FormRequest
             'title' => 'nullable|string|max:255',
             'description' => 'nullable|string|max:65535',
             'amount' => 'nullable|numeric',
+            'status' => 'nullable|in:pending,paid,overdue',
             'due_date' => 'nullable|date',
         ];
     }

--- a/app/Http/Requests/Task/TaskUpdateRequest.php
+++ b/app/Http/Requests/Task/TaskUpdateRequest.php
@@ -24,9 +24,9 @@ class TaskUpdateRequest extends FormRequest
     {
         return [
             'task_category_id' => 'nullable|exists:task_categories,id',
-            'title' => 'string|max:255',
+            'title' => 'nullable|string|max:255',
             'description' => 'nullable|string|max:65535',
-            'due_date' => 'date',
+            'due_date' => 'nullable|date',
         ];
     }
 }

--- a/app/Http/Requests/Transaction/TransactionUpdateRequest.php
+++ b/app/Http/Requests/Transaction/TransactionUpdateRequest.php
@@ -25,8 +25,8 @@ class TransactionUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user_id' => 'exists:users,id',
-            'bill_id' => 'exists:bills,id',
+            'user_id' => 'nullable|exists:users,id',
+            'bill_id' => 'nullable|exists:bills,id',
             'transaction_category_id' => [
                 'required',
                 Rule::exists('transaction_categories', 'id')->where(
@@ -34,11 +34,11 @@ class TransactionUpdateRequest extends FormRequest
                     $this->type
                 ),
             ],
-            'amount' => 'numeric',
-            'type' => 'string|in:income,expense',
-            'description' => 'string|max:65535',
-            'title' => 'nullable|string|max:255',
+            'amount' => 'nullable|numeric',
+            'type' => 'nullable|string|in:income,expense',
             'description' => 'nullable|string|max:65535',
+            'title' => 'nullable|nullable|string|max:255',
+            'description' => 'nullable|nullable|string|max:65535',
         ];
     }
 }

--- a/resources/views/bills/show.blade.php
+++ b/resources/views/bills/show.blade.php
@@ -1,4 +1,11 @@
 <x-app-layout>
+    @if (session('success'))
+        <div id="flash-message"
+            class="absolute z-30 p-4 text-white transition-opacity duration-1000 transform -translate-x-1/2 bg-green-500 rounded-md shadow-md left-1/2">
+            {{ session('success') }}
+        </div>
+    @endif
+
     <x-slot name="header">
     </x-slot>
 

--- a/resources/views/bills/show.blade.php
+++ b/resources/views/bills/show.blade.php
@@ -101,3 +101,14 @@
         </div>
     </div>
 </x-app-layout>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        setTimeout(function() {
+            const flashMessage = document.getElementById('flash-message');
+            if (flashMessage) {
+                flashMessage.classList.add('opacity-0');
+            }
+        }, 3000);
+    });
+</script>

--- a/resources/views/bills/show.blade.php
+++ b/resources/views/bills/show.blade.php
@@ -31,6 +31,21 @@
                                 </svg>
                             </button>
                         </form>
+                        @if ($bill->status !== 'paid')
+                            <form action="{{ route('bills.update', ['bill' => $bill]) }}" method="POST" class="inline">
+                                @csrf
+                                @method('PUT')
+                                <input type="hidden" name="status" value="paid">
+                                <button type="submit" title="{{ __("Change status to 'paid'") }}"
+                                    class="block rounded-full cursor-pointer hover:shadow-inner text-tertiary-txt hover:text-secondary-txt">
+                                    <svg class="w-8 h-8 p-1 rounded-full hover:text-secondary-txt" viewBox="0 0 24 24"
+                                        fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M13 3.5C13 2.94772 12.5523 2.5 12 2.5C11.4477 2.5 11 2.94772 11 3.5V4.0592C9.82995 4.19942 8.75336 4.58509 7.89614 5.1772C6.79552 5.93745 6 7.09027 6 8.5C6 9.77399 6.49167 10.9571 7.5778 11.7926C8.43438 12.4515 9.58764 12.8385 11 12.959V17.9219C10.2161 17.7963 9.54046 17.5279 9.03281 17.1772C8.32378 16.6874 8 16.0903 8 15.5C8 14.9477 7.55228 14.5 7 14.5C6.44772 14.5 6 14.9477 6 15.5C6 16.9097 6.79552 18.0626 7.89614 18.8228C8.75336 19.4149 9.82995 19.8006 11 19.9408V20.5C11 21.0523 11.4477 21.5 12 21.5C12.5523 21.5 13 21.0523 13 20.5V19.9435C14.1622 19.8101 15.2376 19.4425 16.0974 18.8585C17.2122 18.1013 18 16.9436 18 15.5C18 14.1934 17.5144 13.0022 16.4158 12.1712C15.557 11.5216 14.4039 11.1534 13 11.039V6.07813C13.7839 6.20366 14.4596 6.47214 14.9672 6.82279C15.6762 7.31255 16 7.90973 16 8.5C16 9.05228 16.4477 9.5 17 9.5C17.5523 9.5 18 9.05228 18 8.5C18 7.09027 17.2045 5.93745 16.1039 5.17721C15.2467 4.58508 14.1701 4.19941 13 4.0592V3.5ZM11 6.07814C10.2161 6.20367 9.54046 6.47215 9.03281 6.8228C8.32378 7.31255 8 7.90973 8 8.5C8 9.22601 8.25834 9.79286 8.79722 10.2074C9.24297 10.5503 9.94692 10.8384 11 10.9502V6.07814ZM13 13.047V17.9263C13.7911 17.8064 14.4682 17.5474 14.9737 17.204C15.6685 16.7321 16 16.1398 16 15.5C16 14.7232 15.7356 14.1644 15.2093 13.7663C14.7658 13.4309 14.0616 13.1537 13 13.047Z" />
+                                    </svg>
+                                </button>
+                            </form>
+                        @endif
                     </div>
                 </div>
                 <div class="overflow-auto break-all max-h-32">{{ $bill->description }}</div>
@@ -67,6 +82,13 @@
                     <span>Due date:</span>
                     <div>{{ $bill->due_date->format('m-d-Y') }}</div>
                 </div>
+
+                @if ($bill->paid_at)
+                    <div class="flex gap-2">
+                        <span>Paid at</span>
+                        <div>{{ $bill->paid_at->format('m-d-Y') }}</div>
+                    </div>
+                @endif
             </div>
 
         </div>


### PR DESCRIPTION
- A button has been added to bills/show view - for bills that aren't yet paid - to send an update request to change their status to 'paid'.

- When the status update is successful, the user is redirected back to the view, but now not showing anymore the button; showing the 'paid_at' attribute and also a flash message about the successful operation.

![Screenshot_557](https://github.com/user-attachments/assets/37543986-9fdb-482a-a4c3-92a9947ae313)
![Screenshot_558](https://github.com/user-attachments/assets/d8980c8f-f884-4cb0-829b-4c2f9cd3c6d4)