### PR TITLE
feat: add trigger to create a transaction based on paid bills

### DIFF
--- a/database/migrations/2024_06_30_153657_add_triggers_to_bills_table.php
+++ b/database/migrations/2024_06_30_153657_add_triggers_to_bills_table.php
@@ -48,6 +48,30 @@ class AddTriggersToBillsTable extends Migration
                 END IF;
             END;
         ');
+
+        DB::unprepared('
+            CREATE TRIGGER insert_transaction_after_insert_on_bills
+            AFTER INSERT on bills
+            FOR EACH ROW
+            BEGIN
+                if NEW.status = "paid" THEN
+                    INSERT INTO transactions (user_id, bill_id, amount, type, title, description, created_at)
+                    VALUES (NEW.user_id, NEW.id, NEW.amount, "expense", NEW.title, NEW.description, NOW());
+                END IF;
+            END;
+        ');
+
+        DB::unprepared('
+            CREATE TRIGGER insert_transaction_after_update_on_bills
+            AFTER UPDATE on bills
+            FOR EACH ROW
+            BEGIN
+                if NEW.status = "paid" AND OLD.status != "paid" THEN
+                    INSERT INTO transactions (user_id, bill_id, amount, type, title, description, created_at)
+                    VALUES (NEW.user_id, NEW.id, NEW.amount, "expense", NEW.title, NEW.description, NOW());
+                END IF;
+            END;
+        ');
     }
 
     /**
@@ -59,5 +83,11 @@ class AddTriggersToBillsTable extends Migration
     {
         DB::unprepared('DROP TRIGGER IF EXISTS set_paid_at_before_insert');
         DB::unprepared('DROP TRIGGER IF EXISTS set_paid_at_before_update');
+        DB::unprepared(
+            'DROP TRIGGER IF EXISTS insert_transaction_after_insert_on_bills'
+        );
+        DB::unprepared(
+            'DROP TRIGGER IF EXISTS insert_transaction_after_update_on_bills'
+        );
     }
 }


### PR DESCRIPTION
- When a bill gets 'paid', a transaction of type 'expense' is created based on it. That's guaranteed via triggers.

![Screenshot_568](https://github.com/user-attachments/assets/d4a95226-bc79-43d8-8d48-704584b8c6d0)
![Screenshot_569](https://github.com/user-attachments/assets/ce849f66-d398-4fa4-8780-0591df3752c2)