### PR TITLE
Refactor/make test user seeder provide more consistent data avoiding triggers behavior

### DIFF
--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -22,6 +22,7 @@ class Transaction extends Model
         'transaction_category_id',
         'bill_id',
         'user_id',
+        'created_at', // it matters in TransactionFactory
     ];
 
     protected $attributes = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -86,9 +86,13 @@ class User extends Authenticatable
             ->count();
         $totalCount = $pendingBillsCount + $paidBillsCount + $overdueBillsCount;
 
-        $pendingBillsPercentage = ($pendingBillsCount / $totalCount) * 100;
-        $paidBillsPercentage = ($paidBillsCount / $totalCount) * 100;
-        $overdueBillsPercentage = ($overdueBillsCount / $totalCount) * 100;
+        $pendingBillsPercentage = round(
+            ($pendingBillsCount / $totalCount) * 100
+        );
+        $paidBillsPercentage = round(($paidBillsCount / $totalCount) * 100);
+        $overdueBillsPercentage = round(
+            ($overdueBillsCount / $totalCount) * 100
+        );
 
         return "$pendingBillsPercentage x $paidBillsPercentage x $overdueBillsPercentage";
     }
@@ -111,8 +115,8 @@ class User extends Authenticatable
             ->count();
         $totalCount = $incomeCount + $expenseCount;
 
-        $incomePercentage = ($incomeCount / $totalCount) * 100;
-        $expensePercentage = ($expenseCount / $totalCount) * 100;
+        $incomePercentage = round(($incomeCount / $totalCount) * 100, 2);
+        $expensePercentage = round(($expenseCount / $totalCount) * 100, 2);
 
         return "$incomePercentage x $expensePercentage";
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -97,6 +97,7 @@ class User extends Authenticatable
     {
         return $this->transactions()
             ->select('transaction_category_id', DB::raw('count(*) as total'))
+            ->whereNotNull('transaction_category_id')
             ->groupBy('transaction_category_id')
             ->orderBy('total', 'desc')
             ->first()->transactionCategory->name;

--- a/database/factories/BillFactory.php
+++ b/database/factories/BillFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Bill;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -16,21 +17,39 @@ class BillFactory extends Factory
      */
     public function definition(): array
     {
-        $status = $this->faker->randomElement([
-            'pending',
-            'paid',
-            'overdue',
-        ]);
+        $status = $this->faker->randomElement(['pending', 'paid', 'overdue']);
         $due_date = $this->faker->date();
-        $paidAt = $status !== 'paid' ? null : $this->faker->date(max: $due_date);
+        $paidAt =
+            $status !== 'paid' ? null : $this->faker->date(max: $due_date);
 
         return [
             'title' => $this->faker->word,
             'description' => $this->faker->sentence,
-            'amount' => $this->faker->randomFloat(2, 0, 10000),
+            'amount' => $this->faker->randomFloat(2, 0, 5000),
             'due_date' => $due_date,
             'status' => $status,
             'paid_at' => $paidAt,
         ];
+    }
+
+    /**
+     * Configure the factory.
+     *
+     * @return $this
+     */
+    public function configure()
+    {
+        return $this->afterCreating(function (Bill $bill) {
+            if ($bill->status === 'paid') {
+                $bill->transactions()->create([
+                    'user_id' => $bill->user_id,
+                    'bill_id' => $bill->id,
+                    'amount' => -abs($bill->amount),
+                    'type' => 'expense',
+                    'title' => $bill->title,
+                    'description' => $bill->description,
+                ]);
+            }
+        });
     }
 }

--- a/database/factories/BillFactory.php
+++ b/database/factories/BillFactory.php
@@ -18,9 +18,11 @@ class BillFactory extends Factory
     public function definition(): array
     {
         $status = $this->faker->randomElement(['pending', 'paid', 'overdue']);
-        $due_date = $this->faker->date();
+        $due_date = $this->faker->dateTimeBetween('-10 years');
         $paidAt =
-            $status !== 'paid' ? null : $this->faker->date(max: $due_date);
+            $status !== 'paid'
+                ? null
+                : $this->faker->dateTimeBetween('-10 years');
 
         return [
             'title' => $this->faker->word,
@@ -48,6 +50,7 @@ class BillFactory extends Factory
                     'type' => 'expense',
                     'title' => $bill->title,
                     'description' => $bill->description,
+                    'created_at' => $this->faker->dateTimeBetween('-10 years'),
                 ]);
             }
         });

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -39,9 +39,15 @@ class TransactionFactory extends Factory
         // Randomly pick one category ID from the list
         $randomCategoryId = $this->faker->randomElement($categoryIds);
 
+        // Generate a random amount
+        $amount = $this->faker->numberBetween(1, 5000);
+
+        // Ensure the amount is consistent with the type
+        $amount = $type === 'income' ? abs($amount) : -abs($amount);
+
         return [
             'transaction_category_id' => $randomCategoryId,
-            'amount' => $this->faker->numberBetween(1, 1000),
+            'amount' => $amount,
             'type' => $type,
             'title' => $this->faker->sentence(random_int(1, 3)),
             'description' => $this->faker->sentence,

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -51,7 +51,7 @@ class TransactionFactory extends Factory
             'type' => $type,
             'title' => $this->faker->sentence(random_int(1, 3)),
             'description' => $this->faker->sentence,
-            'created_at' => $this->faker->date(),
+            'created_at' => $this->faker->dateTimeBetween('-10 years'),
         ];
     }
 }

--- a/database/seeders/TestUserSeeder.php
+++ b/database/seeders/TestUserSeeder.php
@@ -8,6 +8,8 @@ use App\Models\User;
 use App\Models\Transaction;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 
 class TestUserSeeder extends Seeder
@@ -17,14 +19,23 @@ class TestUserSeeder extends Seeder
      */
     public function run()
     {
-        DB::statement('SET @DISABLE_TRIGGERS = TRUE;');
+        $migrations = glob(database_path('migrations/*.php'));
+
+        $addTriggerMigrations = array_filter($migrations, function (
+            $migration
+        ) {
+            return strpos($migration, 'add_trigger') !== false;
+        });
+
+        $this->dropTriggers(); // ensure that the triggers are dropped (an error occurs when just rolling back)
+        $this->rollbackAddTriggerMigrations($addTriggerMigrations);
 
         $user = User::create([
             'first_name' => 'Augusto',
             'last_name' => 'Henriques',
             'birthdate' => '1990-06-03',
             'email' => 'augustodemelohenriques@gmail.com',
-            'password' => '123123123',
+            'password' => bcrypt('123123123'),
         ]);
 
         Bill::factory()
@@ -45,6 +56,77 @@ class TestUserSeeder extends Seeder
                 'user_id' => $user->id,
             ]);
 
-        DB::statement('SET @DISABLE_TRIGGERS = FALSE;');
+        $this->executeAddTriggerMigrations($addTriggerMigrations);
+    }
+
+    /**
+     * Drop existing triggers in the database.
+     */
+    protected function dropTriggers()
+    {
+        $triggers = [
+            'restrict_paid_at_update',
+            'before_transactions_insert_adjust_amount',
+            'before_transactions_update_adjust_amount',
+            'before_transactions_insert_check_type',
+            'before_transactions_update_check_type',
+            'set_paid_at_before_insert',
+            'set_paid_at_before_update',
+            'insert_transaction_after_insert_on_bills',
+            'insert_transaction_after_update_on_bills',
+            'after_transaction_categories_update_in_type',
+        ];
+
+        foreach ($triggers as $trigger) {
+            try {
+                DB::statement("DROP TRIGGER IF EXISTS $trigger");
+            } catch (\Exception $e) {
+                Log::error("Failed to drop trigger: $trigger", [
+                    'exception' => $e,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Execute the 'add_trigger' migrations.
+     *
+     * @param array $addTriggerMigrations
+     */
+    protected function executeAddTriggerMigrations($addTriggerMigrations)
+    {
+        foreach ($addTriggerMigrations as $migration) {
+            // Convert absolute path to relative path (--path receives only relative ones)
+            $relativePath = str_replace(
+                base_path() . DIRECTORY_SEPARATOR,
+                '',
+                $migration
+            );
+
+            Artisan::call('migrate', [
+                '--path' => $relativePath,
+            ]);
+        }
+    }
+
+    /**
+     * Rollback the 'add_trigger' migrations.
+     *
+     * @param array $addTriggerMigrations
+     */
+    protected function rollbackAddTriggerMigrations($addTriggerMigrations)
+    {
+        foreach ($addTriggerMigrations as $migration) {
+            // Convert absolute path to relative path (--path receives only relative ones)
+            $relativePath = str_replace(
+                base_path() . DIRECTORY_SEPARATOR,
+                '',
+                $migration
+            );
+
+            Artisan::call('migrate:rollback', [
+                '--path' => $relativePath,
+            ]);
+        }
     }
 }

--- a/database/seeders/TestUserSeeder.php
+++ b/database/seeders/TestUserSeeder.php
@@ -33,41 +33,11 @@ class TestUserSeeder extends Seeder
                 'user_id' => $user->id,
             ]);
 
-        // bills trigger to create transaction based on paid bill
-        $bills = $user->bills;
-        foreach ($bills as $bill) {
-            if ($bill->status === 'paid') {
-                if (mt_rand(0, 1)) {
-                    $bill->paid_at = fake()->date($bill->due_date);
-                    $bill->save();
-                }
-
-                $bill->transactions()->create([
-                    'user_id' => $bill->user_id,
-                    'bill_id' => $bill->id,
-                    'amount' => $bill->amount,
-                    'type' => 'expense',
-                    'title' => $bill->title,
-                    'description' => $bill->description,
-                ]);
-            }
-        }
-
         Transaction::factory()
             ->count(5000)
             ->create([
                 'user_id' => $user->id,
             ]);
-
-        // transactions trigger to ensure amount is consistent with type
-        $transactions = $user->transactions;
-        foreach ($transactions as $transaction) {
-            $transaction->amount =
-                $transaction->type === 'income'
-                    ? abs($transaction->amount)
-                    : -abs($transaction->amount);
-        }
-        $transactions->each->save();
 
         Task::factory()
             ->count(5000)

--- a/database/seeders/TestUserSeeder.php
+++ b/database/seeders/TestUserSeeder.php
@@ -4,9 +4,10 @@ namespace Database\Seeders;
 
 use App\Models\Bill;
 use App\Models\Task;
-use App\Models\Transaction;
 use App\Models\User;
+use App\Models\Transaction;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 
 class TestUserSeeder extends Seeder
@@ -16,6 +17,8 @@ class TestUserSeeder extends Seeder
      */
     public function run()
     {
+        DB::statement('SET @DISABLE_TRIGGERS = TRUE;');
+
         $user = User::create([
             'first_name' => 'Augusto',
             'last_name' => 'Henriques',
@@ -25,21 +28,53 @@ class TestUserSeeder extends Seeder
         ]);
 
         Bill::factory()
-            ->count(10)
+            ->count(5000)
             ->create([
                 'user_id' => $user->id,
             ]);
+
+        // bills trigger to create transaction based on paid bill
+        $bills = $user->bills;
+        foreach ($bills as $bill) {
+            if ($bill->status === 'paid') {
+                if (mt_rand(0, 1)) {
+                    $bill->paid_at = fake()->date($bill->due_date);
+                    $bill->save();
+                }
+
+                $bill->transactions()->create([
+                    'user_id' => $bill->user_id,
+                    'bill_id' => $bill->id,
+                    'amount' => $bill->amount,
+                    'type' => 'expense',
+                    'title' => $bill->title,
+                    'description' => $bill->description,
+                ]);
+            }
+        }
 
         Transaction::factory()
-            ->count(10)
+            ->count(5000)
             ->create([
                 'user_id' => $user->id,
             ]);
 
+        // transactions trigger to ensure amount is consistent with type
+        $transactions = $user->transactions;
+        foreach ($transactions as $transaction) {
+            $transaction->amount =
+                $transaction->type === 'income'
+                    ? abs($transaction->amount)
+                    : -abs($transaction->amount);
+        }
+        $transactions->each->save();
+
         Task::factory()
-            ->count(10)
+            ->count(5000)
             ->create([
                 'user_id' => $user->id,
             ]);
+
+        DB::statement('SET @DISABLE_TRIGGERS = FALSE;');
     }
 }

--- a/database/seeders/TestUserSeeder.php
+++ b/database/seeders/TestUserSeeder.php
@@ -29,19 +29,19 @@ class TestUserSeeder extends Seeder
 
         Bill::factory()
             ->count(5000)
-            ->create([
+            ->createQuietly([
                 'user_id' => $user->id,
             ]);
 
         Transaction::factory()
             ->count(5000)
-            ->create([
+            ->createQuietly([
                 'user_id' => $user->id,
             ]);
 
         Task::factory()
             ->count(5000)
-            ->create([
+            ->createQuietly([
                 'user_id' => $user->id,
             ]);
 


### PR DESCRIPTION
- TestUserSeeder before was, due to triggers behavior in database (mysql) level, generating inconsistent data (e.g: all the bills created with 'paid' status got the current timestamp in 'paid_at', no matter if we define the 'paid_at' being logically consistent to 'due_date' in the factory. The triggers are dropped before the factories run and are added again later to let the test data be added properly.

- The observers are also ignored in TestUserSeeder: the cache handling is not potentially triggered on each entity created.

- Fixes and refactors implemented on queries and accessors related to dashboard cards added in previous application update, avoiding crashing on unwanted null values and providing rounded values to end user view.

I've noticed the inconsistency when viewing the chart showing bills and transactions data in the dashboard:

before (always paid bills created with 'paid_at' as the current timestamp)
![Screenshot_571](https://github.com/user-attachments/assets/5e7a9932-5345-4607-afdd-7551d6e412b7)


after
![Screenshot_570](https://github.com/user-attachments/assets/27d03607-7720-47e1-a6cf-0b8da341a65f)

Not in the examples above, but also all the transactions created based on bills where getting 'created_at' with the current timestamp, no matter if the bills were paid times ago.