### PR TITLE
Refactor/integration of searching filtering and sorting together

### DIFF
--- a/app/Http/Controllers/BillController.php
+++ b/app/Http/Controllers/BillController.php
@@ -30,27 +30,37 @@ class BillController extends Controller
 
     public function index(Request $request)
     {
+        $searchTerm = $request->input('searchTerm');
+
         $query = Auth::user()->bills()->getQuery();
 
         $query = Pipeline::send($query)
             ->through([DueDate::class, Amount::class, Status::class])
             ->thenReturn();
 
-        $searchTerm = $request->input('searchTerm');
         $query->when($searchTerm, function ($query, $searchTerm) {
-            $query
-                ->where('title', 'like', '%' . $searchTerm . '%')
-                ->orWhere('description', 'like', '%' . $searchTerm . '%')
-                ->orderByRaw(
-                    "
-                CASE
-                    WHEN title LIKE ? THEN 1
-                    WHEN description LIKE ? THEN 2
-                    ELSE 3
-                END
-            ",
-                    ["%$searchTerm%", "%$searchTerm%"]
-                );
+            $query->where(function ($query) use ($searchTerm) {
+                $query
+                    ->where('title', 'like', '%' . $searchTerm . '%')
+                    ->orWhere('description', 'like', '%' . $searchTerm . '%');
+            });
+
+            $query->orderByRaw(
+                "
+                        CASE
+                            WHEN title LIKE ? AND description LIKE ? THEN 1
+                            WHEN title LIKE ? THEN 2
+                            WHEN description LIKE ? THEN 3
+                            ELSE 4
+                        END
+                        ",
+                [
+                    "%$searchTerm%",
+                    "%$searchTerm%",
+                    "%$searchTerm%",
+                    "%$searchTerm%",
+                ]
+            );
         });
 
         $bills = $query->paginate(10);

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -74,23 +74,23 @@
                 </label>
             </div>
         </div>
-    </form>
 
-    <form class="max-w-lg pb-8">
-        <label for="default-search" class="mb-2 font-medium text-gray-900 sr-only">Search</label>
-        <div class="relative">
-            <div class="absolute inset-y-0 flex items-center pointer-events-none start-0 ps-3">
-                <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true"
-                    xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                        d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z" />
-                </svg>
+        <div class="max-w-lg pb-8">
+            <label for="default-search" class="mb-2 font-medium text-gray-900 sr-only">Search</label>
+            <div class="relative">
+                <div class="absolute inset-y-0 flex items-center pointer-events-none start-0 ps-3">
+                    <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z" />
+                    </svg>
+                </div>
+                <input type="search" name="searchTerm" value="{{ $searchTerm }}"
+                    class="block w-full p-4 text-gray-300 bg-opacity-50 border-none rounded-lg appearance-none bg-secondary-bg ps-10 focus:outline-none focus:ring-2 focus:ring-quinary-bg"
+                    placeholder="{{ __('Search for title or description') }}" />
+                <button type="submit"
+                    class="right-0 absolute end-2.5 bottom-2.5 bg-primary-bg shadow-inner hover:shadow-innerHover text-tertiary-txt font-medium rounded-lg text-sm px-4 py-2">Search</button>
             </div>
-            <input type="search" name="searchTerm" value="{{ $searchTerm }}"
-                class="block w-full p-4 text-gray-300 bg-opacity-50 border-none rounded-lg appearance-none bg-secondary-bg ps-10 focus:outline-none focus:ring-2 focus:ring-quinary-bg"
-                placeholder="{{ __('Search for title or description') }}" />
-            <button type="submit"
-                class="right-0 absolute end-2.5 bottom-2.5 bg-primary-bg shadow-inner hover:shadow-innerHover text-tertiary-txt font-medium rounded-lg text-sm px-4 py-2">Search</button>
         </div>
     </form>
 


### PR DESCRIPTION
## Integration Between Searching, Filtering and Sorting

### Description

 The filter and sorting were not integrated with searching before, now they are able to work together.

### Notes

- Even after making searching and filtering/sorting be part of the same for this wasn't enough: the query generated by the ORM before was allowing, due to badly used boolean expressions, to fetch data inconsistent with the filtering applied (e.g: filtering for bills with status 'completed' and searching for bills with in title or description the searchTerm 'Labore non' and getting a bill that is not 'completed' as part of the result set). This problem has been fixed.
- The query continues to be applying first filtering and then searching, improving performance (the searching is made with a smaller amount of records due to the filtering have already narrowed them down firstly).

### Images

Incorrect query/result:
![Screenshot_559](https://github.com/user-attachments/assets/18e95d5b-3e02-4207-9ffa-874b74d769bd)
![Screenshot_564](https://github.com/user-attachments/assets/b9c040cf-0028-43ea-8b00-2cfeac810593)

Correct query/result
![Screenshot_567](https://github.com/user-attachments/assets/835f1bef-9754-4444-96de-c281eadd072d)
![Screenshot_569](https://github.com/user-attachments/assets/c94665fb-c43b-49f4-a7a5-dc5429f00e59)