### PR TITLE
Refactor/sidebar visual improvement on navigation

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -50,7 +50,7 @@ document.addEventListener('alpine:init', () => {
                 this.isDarkMode = !this.isDarkMode
                 setTheme(this.isDarkMode)
             },
-            isSidebarOpen: window.innerWidth > 1024,
+            isSidebarOpen: false,
             isSidebarHovered: false,
             handleSidebarHover(value) {
                 if (window.innerWidth < 1024) {

--- a/resources/views/components/sidebar/button.blade.php
+++ b/resources/views/components/sidebar/button.blade.php
@@ -1,20 +1,20 @@
 @props([
     'title' => '',
-    'active' => false
+    'active' => false,
 ])
 
 @php
+    $classes = 'transition-colors hover:text-gray-100';
 
-    $classes = 'transition-colors hover:text-gray-900 dark:hover:text-gray-100';
-
-    $active ? ($classes .= ' text-gray-900 dark:text-gray-200') : ($classes .= ' text-gray-500 dark:text-gray-400');
+    $active
+        ? ($classes .= ' text-gray-200 bg-[#e4aa70] shadow-lg hover:bg-[#fac189]')
+        : ($classes .= ' text-gray-400 hover:text-[#fac189]');
 
 @endphp
 
 <li
-    class="relative leading-8 m-0 pl-6 last:before:bg-white last:before:h-auto last:before:top-4 last:before:bottom-0 dark:last:before:bg-dark-eval-1 before:block before:w-4 before:h-0 before:absolute before:left-0 before:top-4 before:border-t-2 before:border-t-gray-200 before:-mt-0.5 dark:before:border-t-gray-600">
+    class="relative leading-8 m-0 pl-6 last:before:h-auto last:before:top-4 last:before:bottom-0 last:before:bg-dark-eval-1 before:block before:w-4 before:h-0 before:absolute before:left-0 before:top-4 before:border-t-2 before:-mt-0.5 before:border-t-gray-600">
     <button type="button" {{ $attributes->merge(['class' => $classes]) }}>
         {{ $title }}
     </button>
 </li>
-

--- a/resources/views/components/sidebar/content.blade.php
+++ b/resources/views/components/sidebar/content.blade.php
@@ -6,28 +6,31 @@
         </x-slot>
     </x-sidebar.link>
 
-    <x-sidebar.dropdown title="{{ __('Charts') }}" :active="Str::startsWith(request()->route()->uri(), 'charts')" isParentDropdown>
-        <x-slot name="icon">
-            <x-heroicon-o-chart-bar class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
-        </x-slot>
-
-        <x-sidebar.dropdown title="{{ __('Transactions') }}" :active="Str::startsWith(request()->route()->uri(), 'transactions')">
+    @if (request()->routeIs('dashboard'))
+        <x-sidebar.dropdown title="{{ __('Charts') }}" isParentDropdown>
             <x-slot name="icon">
-                <x-heroicon-s-switch-horizontal class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
+                <x-heroicon-o-chart-bar class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
             </x-slot>
 
-            <x-sidebar.button class="transactions-total-paid-btn" title="{{ __('Total paid') }}" :active="request()->routeIs('transactions.total_paid')" />
+            <x-sidebar.dropdown title="{{ __('Transactions') }}">
+                <x-slot name="icon">
+                    <x-heroicon-s-switch-horizontal class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
+                </x-slot>
+
+                <x-sidebar.button class="transactions-total-paid-btn" title="{{ __('Total paid') }}"
+                    :active="request()->routeIs('transactions.total_paid')" />
+            </x-sidebar.dropdown>
+
+            <x-sidebar.dropdown title="{{ __('Bills') }}">
+                <x-slot name="icon">
+                    <x-heroicon-o-document-text class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
+                </x-slot>
+
+                <x-sidebar.button class="bills-n-of-paid-btn" title="{{ __('Nº of paid') }}" />
+            </x-sidebar.dropdown>
+
         </x-sidebar.dropdown>
-
-        <x-sidebar.dropdown title="{{ __('Bills') }}" :active="Str::startsWith(request()->route()->uri(), 'bills')">
-            <x-slot name="icon">
-                <x-heroicon-o-document-text class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
-            </x-slot>
-
-            <x-sidebar.button class="bills-n-of-paid-btn" title="{{ __('Nº of paid') }}" :active="request()->routeIs('bills.n_of_paid')" />
-        </x-sidebar.dropdown>
-
-    </x-sidebar.dropdown>
+    @endif
 
     <script></script>
 
@@ -35,17 +38,17 @@
         {{ __('Your things') }}
     </div>
 
-    <x-sidebar.link title="{{ __('Bills') }}" href="{{ route('bills.index') }}">
+    <x-sidebar.link title="{{ __('Bills') }}" href="{{ route('bills.index') }}" :isActive="Str::startsWith(request()->route()->uri(), 'bills')">
         <x-slot:icon>
             <x-heroicon-o-document-text class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
         </x-slot:icon>
     </x-sidebar.link>
-    <x-sidebar.link title="{{ __('Transactions') }}" href="{{ route('transactions.index') }}">
+    <x-sidebar.link title="{{ __('Transactions') }}" href="{{ route('transactions.index') }}" :isActive="Str::startsWith(request()->route()->uri(), 'transactions')">
         <x-slot:icon>
             <x-heroicon-o-switch-horizontal class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
         </x-slot:icon>
     </x-sidebar.link>
-    <x-sidebar.link title="{{ __('Tasks') }}" href="{{ route('tasks.index') }}">
+    <x-sidebar.link title="{{ __('Tasks') }}" href="{{ route('tasks.index') }}" :isActive="Str::startsWith(request()->route()->uri(), 'tasks')">
         <x-slot:icon>
             <x-heroicon-o-clipboard-list class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
         </x-slot:icon>

--- a/resources/views/components/sidebar/header.blade.php
+++ b/resources/views/components/sidebar/header.blade.php
@@ -1,9 +1,9 @@
 <div class="flex items-center justify-between flex-shrink-0 px-3">
     <!-- Logo -->
-    <a href="{{ route('dashboard') }}" class="inline-flex items-center gap-2">
+    <a href="{{ route('home') }}" class="inline-flex items-center gap-2">
         <x-application-logo aria-hidden="true" class="w-10 h-auto" />
 
-        <span class="sr-only">Dashboard</span>
+        <span class="sr-only">Home</span>
     </a>
 
     <!-- Toggle button -->

--- a/resources/views/components/sidebar/link.blade.php
+++ b/resources/views/components/sidebar/link.blade.php
@@ -1,13 +1,14 @@
 @props([
     'isActive' => false,
     'title' => '',
-    'collapsible' => false
+    'collapsible' => false,
+    'active' => false,
 ])
 
 @php
     $isActiveClasses = $isActive
         ? 'text-white bg-[#e4aa70] shadow-lg hover:bg-[#fac189]'
-        : 'text-[#e4aa70] hover:text-gray-700 hover:bg-[#ffedd5] dark:hover:text-[#fac189] dark:hover:bg-dark-eval-2';
+        : 'text-[#e4aa70] hover:text-[#fac189] hover:bg-dark-eval-2';
 
     $classes =
         'flex-shrink-0 flex items-center gap-2 p-2 transition-colors rounded-md overflow-hidden ' . $isActiveClasses;
@@ -29,7 +30,7 @@
             {{ $title }}
         </span>
 
-        <span x-show="isSidebarOpen || isSidebarHovered" aria-hidden="true" class="relative block ml-auto w-6 h-6">
+        <span x-show="isSidebarOpen || isSidebarHovered" aria-hidden="true" class="relative block w-6 h-6 ml-auto">
             <span :class="open ? '-rotate-45' : 'rotate-45'"
                 class="absolute right-[9px] bg-[#e4aa70] mt-[-5px] h-2 w-[2px] top-1/2 transition-all duration-200"></span>
 
@@ -50,4 +51,3 @@
         </span>
     </a>
 @endif
-


### PR DESCRIPTION
## Sidebar Navigation and Dynamic State Improvement

### Description
 The sidebar provides now the user where they are currently navigating on, makes possible for them to go to 'home' route and do not start fullly opened in every refresh in lg+ devices.

### Notes

- 'Charts' options are only showed navigating in 'dashboard' route (the options only change the content showed in the chart in dashboard, so in any other place it wasn't useful.
- Application's logo link points not anymore to 'dashboard', but to 'home': now there's a way to go by UI to 'home' route.
- In larger-size devices (following tailwindcss convention), the sidebar is not open up; only the user can manually open it on hover.

### Images

![Screenshot_579](https://github.com/user-attachments/assets/e9acaaf0-60a0-416f-92f0-bbe2e3346681)
