### PR TITLE
Feature/dashboard chart new data on types and status in days

### DIFF
--- a/app/Http/Controllers/BillChartController.php
+++ b/app/Http/Controllers/BillChartController.php
@@ -20,30 +20,29 @@ class BillChartController extends Controller
 
     public function fetchChartData(Request $request)
     {
-        $chartData = $this->getChartDataByInterval(
-            $request->input('type', 'yearly'),
-            $request->input('length', '1')
+        $chartData = $this->getBillChartData(
+            $request->input('type', 'pending'),
+            (int) $request->input('length', 7)
         );
 
         return response()->json($chartData);
     }
 
-    protected function getChartDataByInterval($type, $length)
+    protected function getBillChartData($type, $length)
     {
         switch ($type) {
-            case 'daily':
-                $chartData = $this->billChartDataService->getNumberOfDailyPaidBills(
+            case 'pending':
+                $chartData = $this->billChartDataService->getBillsTotalAmountToBePaidInNextDays(
                     $length
                 );
                 break;
-            case 'monthly':
-                $chartData = $this->billChartDataService->getNumberOfMonthlyPaidBills(
+            case 'paid':
+                $chartData = $this->billChartDataService->getBillsTotalAmountPaidInLastDays(
                     $length
                 );
                 break;
-            case 'yearly':
             default:
-                $chartData = $this->billChartDataService->getNumberOfYearlyPaidBills(
+                $chartData = $this->billChartDataService->getBillsTotalAmountToBePaidInNextDays(
                     $length
                 );
                 break;

--- a/app/Http/Controllers/TransactionChartController.php
+++ b/app/Http/Controllers/TransactionChartController.php
@@ -3,11 +3,12 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Auth;
+use App\Charts\DailyTransactionsChart;
 use App\Charts\YearlyTransactionsChart;
 use App\Charts\MonthlyTransactionsChart;
-use App\Charts\DailyTransactionsChart;
 use App\Services\TransactionChartDataService;
-use Illuminate\Support\Facades\Auth;
 
 class TransactionChartController extends Controller
 {
@@ -21,30 +22,29 @@ class TransactionChartController extends Controller
 
     public function fetchChartData(Request $request)
     {
-        $chartData = $this->getChartDataByInterval(
-            $request->input('type', 'yearly'),
-            $request->input('length', '1')
+        $chartData = $this->getTransactionChartData(
+            $request->input('type', 'income'),
+            (int) $request->input('length', 7)
         );
 
         return response()->json($chartData);
     }
 
-    protected function getChartDataByInterval($type, $length)
+    protected function getTransactionChartData($type, $length)
     {
         switch ($type) {
-            case 'daily':
-                $chartData = $this->transactionChartDataService->getTotalAmountOnTransactionsDaily(
+            case 'income':
+                $chartData = $this->transactionChartDataService->getTotalIncomeOnTransactionsInLastDays(
                     $length
                 );
                 break;
-            case 'monthly':
-                $chartData = $this->transactionChartDataService->getTotalAmountOnTransactionsMonthly(
+            case 'expense':
+                $chartData = $this->transactionChartDataService->getTotalExpenseOnTransactionsInLastDays(
                     $length
                 );
                 break;
-            case 'yearly':
             default:
-                $chartData = $this->transactionChartDataService->getTotalAmountOnTransactionsYearly(
+                $chartData = $this->transactionChartDataService->getTotalIncomeOnTransactionsInLastDays(
                     $length
                 );
                 break;

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -251,5 +251,12 @@
     "Paid at:": "Pago em:",
     "created at": "data de criação",
     "You have one or more bills now overdue.": "Você possui uma ou mais contas em atrasado no momento.",
-    "Make sure to pay them as soon as possible to avoid extra fees.": "Certifique-se de pagá-las assim que possível para evitar cobranças extra."
+    "Make sure to pay them as soon as possible to avoid extra fees.": "Certifique-se de pagá-las assim que possível para evitar cobranças extra.",
+    "Days": "Dias",
+    "in last :days days": "nos últimos :days dias",
+    "in next :days days": "nos próximos :days dias",
+    "$ of income on transactions": "R$ de renda em transações",
+    "$ of expense on transactions": "R$ de despesa em transações",
+    "$ to pay in bills": "R$ a pagar em contas",
+    "$ paid in bills": "R$ pago em contas"
 }

--- a/resources/views/components/sidebar/content.blade.php
+++ b/resources/views/components/sidebar/content.blade.php
@@ -6,32 +6,6 @@
         </x-slot>
     </x-sidebar.link>
 
-    @if (request()->routeIs('dashboard'))
-        <x-sidebar.dropdown title="{{ __('Charts') }}" isParentDropdown>
-            <x-slot name="icon">
-                <x-heroicon-o-chart-bar class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
-            </x-slot>
-
-            <x-sidebar.dropdown title="{{ __('Transactions') }}">
-                <x-slot name="icon">
-                    <x-heroicon-s-switch-horizontal class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
-                </x-slot>
-
-                <x-sidebar.button class="transactions-total-paid-btn" title="{{ __('Total paid') }}"
-                    :active="request()->routeIs('transactions.total_paid')" />
-            </x-sidebar.dropdown>
-
-            <x-sidebar.dropdown title="{{ __('Bills') }}">
-                <x-slot name="icon">
-                    <x-heroicon-o-document-text class="flex-shrink-0 w-6 h-6" aria-hidden="true" />
-                </x-slot>
-
-                <x-sidebar.button class="bills-n-of-paid-btn" title="{{ __('Nº of paid') }}" />
-            </x-sidebar.dropdown>
-
-        </x-sidebar.dropdown>
-    @endif
-
     <script></script>
 
     <div x-transition x-show="isSidebarOpen || isSidebarHovered" class="text-sm text-gray-500">

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -192,13 +192,5 @@
         });
         selectTypeOrStatus.addEventListener('change', updateChart);
         selectLength.addEventListener('change', updateChart);
-        document.querySelector('.transactions-data-btn').addEventListener('click', () => {
-            selectDataType.selectedIndex = 0;
-            updateChart();
-        });
-        document.querySelector('.bills-data-btn').addEventListener('click', () => {
-            selectDataType.selectedIndex = 1;
-            updateChart();
-        });
     </script>
 </x-app-layout>


### PR DESCRIPTION
## New Dashboard Chart on Types/Status of Transactions/Bills in Days

### Description
 The chart in 'dashboard' view has new options of data to show based on types of transactions / status of bills in the last/next 7, 14 or 28 days.

### Notes

- data options available provide the user the following data: 
  - Total income in the last X days. (transactions)
  - Total expense in the last X days. (transactions)
  - Total amount paid on bills in the last X days. (bills)
  - Total amount to pay on bills in the next X days. (bills)
  
- The previous data options have been removed from views, but are still available in chartDataServices.
- The idea on implementing these changes is to make the dashboard view more useful for both new users and old ones (probably in the future a view for other data visualization options, including the now old ones (e.g: transactions made in the last year with a monthly interval) will be created).
- The 'charts' dropdown in sidebar has been removed due to not being useful anymore (the selects in 'dashboard' view do the same and more easily).
- The charts now never are empty for visualization: even if, for exemple, there's no bills to be paid in the next 7 days, the data on each of the next 7 days gets "0" as value to be shown in the dashboard chart. 

### Images

Before
![Screenshot_586](https://github.com/user-attachments/assets/21c15748-55af-4bae-aaa3-34703a05174a)

After
![Screenshot_584](https://github.com/user-attachments/assets/8355e589-18d1-4904-99fa-86aefc508ccc)
![Screenshot_583](https://github.com/user-attachments/assets/638d27c8-37ae-488e-8292-24dcdb7451b0)