### PR TITLE
Refactor/chart related code

### DIFF
--- a/app/Http/Controllers/BillChartController.php
+++ b/app/Http/Controllers/BillChartController.php
@@ -3,10 +3,6 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Charts\DailyPaidBillsChart;
-use App\Charts\YearlyPaidBillsChart;
-use Illuminate\Support\Facades\Auth;
-use App\Charts\MonthlyPaidBillsChart;
 use App\Services\BillChartDataService;
 
 class BillChartController extends Controller
@@ -18,18 +14,11 @@ class BillChartController extends Controller
         $this->billChartDataService = $billChartDataService;
     }
 
-    public function fetchChartData(Request $request)
+    public function __invoke(Request $request)
     {
-        $chartData = $this->getBillChartData(
-            $request->input('type', 'pending'),
-            (int) $request->input('length', 7)
-        );
+        $type = $request->input('type', 'pending');
+        $length = (int) $request->input('length', 7);
 
-        return response()->json($chartData);
-    }
-
-    protected function getBillChartData($type, $length)
-    {
         switch ($type) {
             case 'pending':
                 $chartData = $this->billChartDataService->getBillsTotalAmountToBePaidInNextDays(
@@ -48,6 +37,6 @@ class BillChartController extends Controller
                 break;
         }
 
-        return $chartData;
+        return response()->json($chartData);
     }
 }

--- a/app/Http/Controllers/TransactionChartController.php
+++ b/app/Http/Controllers/TransactionChartController.php
@@ -3,35 +3,22 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Auth;
-use App\Charts\DailyTransactionsChart;
-use App\Charts\YearlyTransactionsChart;
-use App\Charts\MonthlyTransactionsChart;
 use App\Services\TransactionChartDataService;
 
 class TransactionChartController extends Controller
 {
     protected $transactionChartDataService;
 
-    public function __construct(
-        TransactionChartDataService $transactionChartDataService
-    ) {
+    public function __construct(TransactionChartDataService $transactionChartDataService)
+    {
         $this->transactionChartDataService = $transactionChartDataService;
     }
 
-    public function fetchChartData(Request $request)
+    public function __invoke(Request $request)
     {
-        $chartData = $this->getTransactionChartData(
-            $request->input('type', 'income'),
-            (int) $request->input('length', 7)
-        );
+        $type = $request->input('type', 'pending');
+        $length = (int) $request->input('length', 7);
 
-        return response()->json($chartData);
-    }
-
-    protected function getTransactionChartData($type, $length)
-    {
         switch ($type) {
             case 'income':
                 $chartData = $this->transactionChartDataService->getTotalIncomeOnTransactionsInLastDays(
@@ -50,6 +37,6 @@ class TransactionChartController extends Controller
                 break;
         }
 
-        return $chartData;
+        return response()->json($chartData);
     }
 }

--- a/app/Services/BillChartDataService.php
+++ b/app/Services/BillChartDataService.php
@@ -18,12 +18,13 @@ class BillChartDataService
     {
         $startDate = now()->startOfDay();
         $endDate = now()->addDays($length)->endOfDay();
+        $dateFormat = getDateFormatForChartDataQuery();
 
         $bills = $this->user
             ->bills()
             ->whereBetween('due_date', [$startDate, $endDate])
             ->where('status', 'pending')
-            ->selectRaw('DATE(due_date) as date, SUM(amount) as total_amount')
+            ->selectRaw("DATE_FORMAT(due_date, '{$dateFormat}') as date, SUM(amount) as total_amount")
             ->groupBy('date')
             ->orderBy('date')
             ->get()
@@ -34,9 +35,9 @@ class BillChartDataService
         $data = [];
 
         foreach ($period as $date) {
-            $formattedDate = $date->format('Y-m-d');
+            $formattedDate = formatDate($date);
             $labels[] = $formattedDate;
-            $data[] = $bills->get($formattedDate)->total_amount ?? 0;
+            $data[] = $bills->get(formatDate($date))->total_amount ?? 0;
         }
 
         return [
@@ -55,12 +56,13 @@ class BillChartDataService
     {
         $startDate = now()->subDays($length)->startOfDay();
         $endDate = now()->endOfDay();
+        $dateFormat = getDateFormatForChartDataQuery();
 
         $bills = $this->user
             ->bills()
             ->whereBetween('paid_at', [$startDate, $endDate])
             ->where('status', 'paid')
-            ->selectRaw('DATE(paid_at) as date, SUM(amount) as total_amount')
+            ->selectRaw("DATE_FORMAT(paid_at, '{$dateFormat}') as date, SUM(amount) as total_amount")
             ->groupBy('date')
             ->orderBy('date')
             ->get()
@@ -71,9 +73,9 @@ class BillChartDataService
         $data = [];
 
         foreach ($period as $date) {
-            $formattedDate = $date->format('Y-m-d');
+            $formattedDate = formatDate($date);
             $labels[] = $formattedDate;
-            $data[] = $bills->get($formattedDate)->total_amount ?? 0;
+            $data[] = $bills->get(formatDate($date))->total_amount ?? 0;
         }
 
         return [

--- a/app/Services/TransactionChartDataService.php
+++ b/app/Services/TransactionChartDataService.php
@@ -19,12 +19,13 @@ class TransactionChartDataService
     {
         $startDate = now()->subDays($length)->startOfDay();
         $endDate = now()->endOfDay();
+        $dateFormat = getDateFormatForChartDataQuery();
 
         $transactions = $this->user
             ->transactions()
             ->whereBetween('created_at', [$startDate, $endDate])
             ->where('type', 'income')
-            ->selectRaw('DATE(created_at) as date, SUM(amount) as total_amount')
+            ->selectRaw("DATE_FORMAT(created_at, '{$dateFormat}') as date, SUM(amount) as total_amount")
             ->groupBy('date')
             ->orderBy('date')
             ->get()
@@ -35,9 +36,9 @@ class TransactionChartDataService
         $data = [];
 
         foreach ($period as $date) {
-            $formattedDate = $date->format('Y-m-d');
+            $formattedDate = formatDate($date);
             $labels[] = $formattedDate;
-            $data[] = $transactions->get($formattedDate)->total_amount ?? 0;
+            $data[] = $transactions->get(formatDate($date))->total_amount ?? 0;
         }
 
         return [
@@ -56,12 +57,13 @@ class TransactionChartDataService
     {
         $startDate = now()->subDays($length)->startOfDay();
         $endDate = now()->endOfDay();
+        $dateFormat = getDateFormatForChartDataQuery();
 
         $transactions = $this->user
             ->transactions()
             ->whereBetween('created_at', [$startDate, $endDate])
             ->where('type', 'expense')
-            ->selectRaw('DATE(created_at) as date, SUM(amount) as total_amount')
+            ->selectRaw("DATE_FORMAT(created_at, '{$dateFormat}') as date, SUM(amount) as total_amount")
             ->groupBy('date')
             ->orderBy('date')
             ->get()
@@ -72,9 +74,9 @@ class TransactionChartDataService
         $data = [];
 
         foreach ($period as $date) {
-            $formattedDate = $date->format('Y-m-d');
+            $formattedDate = formatDate($date);
             $labels[] = $formattedDate;
-            $data[] = $transactions->get($formattedDate)->total_amount ?? 0;
+            $data[] = $transactions->get(formatDate($date))->total_amount ?? 0;
         }
 
         return [

--- a/app/View/Components/Chart.php
+++ b/app/View/Components/Chart.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Chart extends Component
+{
+    public function __construct() {}
+
+    public function render(): View|Closure|string
+    {
+        return view('components.chart');
+    }
+}

--- a/resources/views/components/chart.blade.php
+++ b/resources/views/components/chart.blade.php
@@ -1,0 +1,50 @@
+<canvas id="chart"></canvas>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script defer>
+    const selectDataType = document.getElementById('select-data-type');
+    const selectTypeOrStatus = document.getElementById('select-type-or-status');
+    const selectLength = document.getElementById('select-length');
+    const labelSelectTypeOrStatus = document.querySelector('#label-type-or-status');
+    const ctx = document.getElementById('chart');
+
+    const chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            datasets: [{
+                backgroundColor: '#FAC189',
+                borderColor: '#FAC189',
+            }],
+        },
+        options: {
+            maintainAspectRatio: false
+        }
+    });
+
+    updateChart();
+
+    function updateChart() {
+        const dataType = selectDataType.value;
+        const body = {
+            type: selectTypeOrStatus.value,
+            length: selectLength.value
+        };
+
+        fetch(`/api/chart-data/${dataType}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                },
+                body: JSON.stringify(body),
+            })
+            .then(response => response.json())
+            .then(data => {
+                chart.data.labels = data.labels;
+                chart.data.datasets[0].data = data.dataset.data;
+                chart.data.datasets[0].label = data.dataset.label;
+                chart.data.datasets[0].showLine = data.dataset.showLine;
+                chart.update();
+            });
+    }
+</script>

--- a/resources/views/components/columns.blade.php
+++ b/resources/views/components/columns.blade.php
@@ -8,7 +8,7 @@
             $attributes = (new App\Models\Transaction())->getFillable();
             break;
         case 'bill':
-            $attributes = (new App\Models\Bill())->getFillable();
+            $attributes = array_merge((new App\Models\Bill())->getFillable(), ['paid_at']);
             break;
         case 'task':
             $attributes = (new App\Models\Task())->getFillable();
@@ -20,6 +20,7 @@
         'transaction_category_id' => __('category'),
         'task_category_id' => __('category'),
         'created_at' => __('created at'),
+        'due_date' => __('due date'),
         'paid_at' => __('paid at'),
     ];
 

--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -15,6 +15,14 @@
         'created_at' => formatDate($instance->created_at),
     ];
 
+    $attributes = class_basename($instance) !== 'Bill' ? $instance->getFillable() : array_merge($instance->getFillable(), ['paid_at']);
+
+    $filteredAttributes = array_filter($attributes, function ($attribute) {
+        return $attribute !== 'user_id';
+    });
+@endphp
+
+@php
     $transformAttribute = function ($attribute, $instance, $mapping) {
         if (array_key_exists($attribute, $mapping)) {
             return $mapping[$attribute] ?? 'N/A';
@@ -22,12 +30,6 @@
 
         return $instance->$attribute ?? 'N/A';
     };
-
-    $attributes = $instance->getFillable();
-
-    $filteredAttributes = array_filter($attributes, function ($attribute) {
-        return $attribute !== 'user_id';
-    });
 @endphp
 
 @foreach ($filteredAttributes as $attribute)

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -89,7 +89,7 @@
                             </p>
                         </div>
                     @endif
-                    <canvas id="chart"></canvas>
+                    <x-chart />
                 </div>
             </div>
 
@@ -100,54 +100,7 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
-        const selectDataType = document.getElementById('select-data-type');
-        const selectTypeOrStatus = document.getElementById('select-type-or-status');
-        const selectLength = document.getElementById('select-length');
-        const labelSelectTypeOrStatus = document.querySelector('#label-type-or-status');
-
-        const ctx = document.getElementById('chart');
-
-        const chart = new Chart(ctx, {
-            type: 'line',
-            data: {
-                datasets: [{
-                    backgroundColor: '#FAC189',
-                    borderColor: '#FAC189',
-                }],
-            },
-            options: {
-                maintainAspectRatio: false
-            }
-        });
-        updateChart();
-
-        function updateChart() {
-            const dataType = selectDataType.value;
-            const body = {
-                type: selectTypeOrStatus.value,
-                length: selectLength.value
-            };
-
-            fetch(`/api/chart-data/${dataType}`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-                    },
-                    body: JSON.stringify(body),
-                })
-                .then(response => response.json())
-                .then(data => {
-                    chart.data.labels = data.labels;
-                    chart.data.datasets[0].data = data.dataset.data;
-                    chart.data.datasets[0].label = data.dataset.label;
-                    chart.data.datasets[0].showLine = data.dataset.showLine;
-                    chart.update();
-                });
-        }
-
         selectDataType.addEventListener('change', () => {
             const selectTypeOptions = {
                 bills: [{

--- a/routes/custom/dashboard.php
+++ b/routes/custom/dashboard.php
@@ -10,12 +10,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
         return view('dashboard');
     })->name('dashboard');
 
-    Route::post('/api/chart-data/transactions', [
-        TransactionChartController::class,
-        'fetchChartData',
-    ]);
-    Route::post('/api/chart-data/bills', [
-        BillChartController::class,
-        'fetchChartData',
-    ]);
+    Route::post('/api/chart-data/transactions', TransactionChartController::class);
+    Route::post('/api/chart-data/bills', BillChartController::class);
 });


### PR DESCRIPTION
## Refactor Dashboard Chart (Controllers, Componentization)

### Description
Logic from bill/transactionChart controllers and dashboard's view has been refactored.

### Notes
- Transaction/bill controllers, whose target is to pass to the dashboards' chart the amount of added records related to these entities recently (e.g: total amount paid in bills in the last 7 days), was confusing:
  - Method called by the route configured to receive requests for changing chart's data was named 'fetchChartData', and it was calling another method from the same controller named 'getChartData'. From their names, beyond no way to infer what happens, i prefer to mantain controllers organized in this pattern in general:
    -- resourceful controllers (crud ones)
    -- "invokable" controllers (one-method controllers specific for getting "secondary resources" - data not crucial for the application, but involved in features such as language-switch preference, notification-reading and so on.
 -  Logic from chart manipulation and its html has been moved from dashboard's view to a dedicated one.
 - Chart data exhibition now takes user's language preference in consideration:
   - Our customized helper "getDateFormatForChartDataQuery" is now used by all queries from "ChartData" services.
 - A fix was made by identifying a nonexistent problem related to queries:
   - In bill's index view i thought i could find bills that matched the result expected by queries involving paid bills, but the query wasn't returning them. I was wrong: the view only showed actually 'due_date' of bills; 'paid_at' wasn't present. So i added it there.